### PR TITLE
[1.x] Test custom mongo odm types

### DIFF
--- a/src/Foundation/Exception/InvalidArgumentException.php
+++ b/src/Foundation/Exception/InvalidArgumentException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Foundation\Exception;
+
+class InvalidArgumentException extends SiklidException
+{
+    public static function create(string $expected, string $got): self
+    {
+        return new self(
+            sprintf(
+                'Expected instance of %s, got %s',
+                $expected,
+                $got
+            )
+        );
+    }
+}

--- a/src/Foundation/Exception/InvalidArgumentException.php
+++ b/src/Foundation/Exception/InvalidArgumentException.php
@@ -10,7 +10,7 @@ class InvalidArgumentException extends SiklidException
     {
         return new self(
             sprintf(
-                'Expected instance of %s, got %s',
+                'Expected instance of %s, got %s.',
                 $expected,
                 $got
             )

--- a/src/Foundation/ValueObject/Username.php
+++ b/src/Foundation/ValueObject/Username.php
@@ -14,9 +14,9 @@ use Stringable;
  */
 final class Username implements Stringable, JsonSerializable
 {
-    private readonly string $username;
+    public readonly string $username;
 
-    private readonly string $original;
+    public readonly string $original;
 
     private function __construct(string $username, string $original)
     {
@@ -54,5 +54,10 @@ final class Username implements Stringable, JsonSerializable
     public function jsonSerialize(): string
     {
         return $this->username;
+    }
+
+    public function equals(Username $other): bool
+    {
+        return $this->username === $other->username;
     }
 }

--- a/src/Foundation/ValueType/CoercibleEnum.php
+++ b/src/Foundation/ValueType/CoercibleEnum.php
@@ -14,7 +14,7 @@ interface CoercibleEnum extends BackedEnum
     /**
      * Coerce value to enum.
      */
-    public static function coerce(self|string $value): self;
+    public static function coerce(mixed $value): self;
 
     /**
      * Converts the enum to an array.

--- a/src/Foundation/ValueType/EmailType.php
+++ b/src/Foundation/ValueType/EmailType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Foundation\ValueType;
 
+use App\Foundation\Exception\InvalidArgumentException;
 use App\Foundation\ValueObject\Email;
 use Doctrine\ODM\MongoDB\Types\ClosureToPHP;
 use Doctrine\ODM\MongoDB\Types\Type;
@@ -14,11 +15,19 @@ class EmailType extends Type
 
     public function convertToDatabaseValue($value): string
     {
+        if (! $value instanceof Email) {
+            throw InvalidArgumentException::create(Email::class, get_debug_type($value));
+        }
+
         return (string)$value;
     }
 
-    public function convertToPHPValue($value): ?Email
+    public function convertToPHPValue($value): Email
     {
-        return is_string($value) ? Email::fromString($value) : null;
+        if (null === $value) {
+            throw new InvalidArgumentException('Null value should be skipped by Doctrine.');
+        }
+
+        return Email::fromString($value);
     }
 }

--- a/src/Foundation/ValueType/EmailType.php
+++ b/src/Foundation/ValueType/EmailType.php
@@ -28,6 +28,6 @@ class EmailType extends Type
             throw new InvalidArgumentException('Null value should be skipped by Doctrine.');
         }
 
-        return Email::fromString($value);
+        return Email::fromString((string)$value);
     }
 }

--- a/src/Foundation/ValueType/SlugType.php
+++ b/src/Foundation/ValueType/SlugType.php
@@ -28,6 +28,6 @@ class SlugType extends Type
             throw new InvalidArgumentException('Null values should be skipped by Doctrine.');
         }
 
-        return Slug::fromString($value);
+        return Slug::fromString((string)$value);
     }
 }

--- a/src/Foundation/ValueType/SlugType.php
+++ b/src/Foundation/ValueType/SlugType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Foundation\ValueType;
 
+use App\Foundation\Exception\InvalidArgumentException;
 use App\Foundation\ValueObject\Slug;
 use Doctrine\ODM\MongoDB\Types\ClosureToPHP;
 use Doctrine\ODM\MongoDB\Types\Type;
@@ -14,11 +15,19 @@ class SlugType extends Type
 
     public function convertToDatabaseValue($value): string
     {
+        if (! $value instanceof Slug) {
+            throw new InvalidArgumentException('SlugType can process only Slug value object.');
+        }
+
         return (string)$value;
     }
 
-    public function convertToPHPValue($value): ?Slug
+    public function convertToPHPValue($value): Slug
     {
-        return is_string($value) ? Slug::fromString($value) : null;
+        if (null === $value) {
+            throw new InvalidArgumentException('Null values should be skipped by Doctrine.');
+        }
+
+        return Slug::fromString($value);
     }
 }

--- a/src/Foundation/ValueType/SlugType.php
+++ b/src/Foundation/ValueType/SlugType.php
@@ -16,7 +16,7 @@ class SlugType extends Type
     public function convertToDatabaseValue($value): string
     {
         if (! $value instanceof Slug) {
-            throw new InvalidArgumentException('SlugType can process only Slug value object.');
+            throw InvalidArgumentException::create(Slug::class, get_debug_type($value));
         }
 
         return (string)$value;

--- a/src/Foundation/ValueType/SpecificType.php
+++ b/src/Foundation/ValueType/SpecificType.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Foundation\ValueType;
 
+use App\Foundation\Exception\InvalidArgumentException;
 use Doctrine\ODM\MongoDB\Types\ClosureToPHP;
 use Doctrine\ODM\MongoDB\Types\Type;
-use InvalidArgumentException;
 
 /**
  * This type is used to map Enum values to MongoDB.
@@ -21,7 +21,7 @@ class SpecificType extends Type
             return $value->toArray();
         }
 
-        throw new InvalidArgumentException('Value must be an instance of UnitEnum');
+        throw InvalidArgumentException::create(CoercibleEnum::class, get_debug_type($value));
     }
 
     public function convertToPHPValue($value): CoercibleEnum
@@ -29,22 +29,20 @@ class SpecificType extends Type
         if (is_array($value) && isset($value['name'], $value['value'])) {
             /** @var class-string<CoercibleEnum> $name */
             $name = $value['name'];
-            /** @var string $data */
-            $data = $value['value'];
 
-            return $this->toPHP($name, $data);
+            return $this->toPHP($name, $value['value']);
         }
 
-        throw new InvalidArgumentException('Value must be an array with name and value keys');
+        throw new InvalidArgumentException('Value must be an array with name and value keys.');
     }
 
     /**
      * @param class-string<CoercibleEnum> $enum  full qualified name of the enum
-     * @param string                      $value the value of the backed enum
+     * @param mixed                       $value the value of the backed enum
      *
      * @return CoercibleEnum the enum instance
      */
-    private function toPHP(string $enum, string $value): CoercibleEnum
+    private function toPHP(string $enum, mixed $value): CoercibleEnum
     {
         return $enum::coerce($value);
     }

--- a/src/Foundation/ValueType/UsernameType.php
+++ b/src/Foundation/ValueType/UsernameType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Foundation\ValueType;
 
+use App\Foundation\Exception\InvalidArgumentException;
 use App\Foundation\ValueObject\Username;
 use Doctrine\ODM\MongoDB\Types\ClosureToPHP;
 use Doctrine\ODM\MongoDB\Types\Type;
@@ -14,11 +15,19 @@ class UsernameType extends Type
 
     public function convertToDatabaseValue($value): string
     {
+        if (! $value instanceof Username) {
+            throw InvalidArgumentException::create('UsernameType', get_debug_type($value));
+        }
+
         return (string)$value;
     }
 
-    public function convertToPHPValue($value): ?Username
+    public function convertToPHPValue($value): Username
     {
-        return is_string($value) ? Username::fromString($value) : null;
+        if (null === $value) {
+            throw new InvalidArgumentException('Null values should be skipped by Doctrine.');
+        }
+
+        return Username::fromString($value);
     }
 }

--- a/src/Foundation/ValueType/UsernameType.php
+++ b/src/Foundation/ValueType/UsernameType.php
@@ -28,6 +28,6 @@ class UsernameType extends Type
             throw new InvalidArgumentException('Null values should be skipped by Doctrine.');
         }
 
-        return Username::fromString($value);
+        return Username::fromString((string)$value);
     }
 }

--- a/src/Siklid/Application/Contract/Type/RepetitionAlgorithm.php
+++ b/src/Siklid/Application/Contract/Type/RepetitionAlgorithm.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Siklid\Application\Contract\Type;
 
 use App\Foundation\ValueType\CoercibleEnum;
-use InvalidArgumentException;
 
 /**
  * Repetition algorithm type.
@@ -14,17 +13,13 @@ enum RepetitionAlgorithm: string implements CoercibleEnum
 {
     case Leitner = 'leitner';
 
-    public static function coerce(string|CoercibleEnum $value): self
+    public static function coerce(mixed $value): self
     {
         if ($value instanceof self) {
             return $value;
         }
 
-        if (! is_string($value)) {
-            throw new InvalidArgumentException('Value must be a string or an instance of RepetitionAlgorithm');
-        }
-
-        return self::from($value);
+        return self::from((string)$value);
     }
 
     public function toArray(): array

--- a/src/Siklid/Command/SetupCommand.php
+++ b/src/Siklid/Command/SetupCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Siklid\Command;
 
+use App\Foundation\ValueObject\Email;
 use App\Foundation\ValueObject\Username;
 use App\Siklid\Document\User;
 use Doctrine\ODM\MongoDB\DocumentManager;
@@ -62,7 +63,7 @@ class SetupCommand extends Console
         $user->setUsername(Username::fromString('admin'));
         // @todo: config admin password or ask for it
         $user->setPassword($this->hasher->hash('admin'));
-        $user->setEmail('admin@siklid.io');
+        $user->setEmail(Email::fromString('admin@siklid.io'));
 
         $this->dm->persist($user);
         $this->dm->flush();

--- a/src/Siklid/Command/SetupCommand.php
+++ b/src/Siklid/Command/SetupCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Siklid\Command;
 
+use App\Foundation\ValueObject\Username;
 use App\Siklid\Document\User;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -48,7 +49,7 @@ class SetupCommand extends Console
     private function createAdminUser(): void
     {
         $usersRepository = $this->dm->getRepository(User::class);
-        $exists = $usersRepository->findOneBy(['username' => 'admin']);
+        $exists = $usersRepository->findOneBy(['username' => Username::fromString('admin')]);
 
         if ($exists) {
             $this->warning('- Admin user already exists.');
@@ -58,7 +59,7 @@ class SetupCommand extends Console
 
         $user = new User();
 
-        $user->setUsername('admin');
+        $user->setUsername(Username::fromString('admin'));
         // @todo: config admin password or ask for it
         $user->setPassword($this->hasher->hash('admin'));
         $user->setEmail('admin@siklid.io');

--- a/src/Siklid/Document/Box.php
+++ b/src/Siklid/Document/Box.php
@@ -153,9 +153,9 @@ class Box implements BoxInterface
         return $this->repetitionAlgorithm;
     }
 
-    public function setRepetitionAlgorithm(RepetitionAlgorithm|string $repetitionAlgorithm): Box
+    public function setRepetitionAlgorithm(RepetitionAlgorithm $repetitionAlgorithm): Box
     {
-        $this->repetitionAlgorithm = RepetitionAlgorithm::coerce($repetitionAlgorithm);
+        $this->repetitionAlgorithm = $repetitionAlgorithm;
 
         return $this;
     }

--- a/src/Siklid/Document/User.php
+++ b/src/Siklid/Document/User.php
@@ -73,9 +73,9 @@ class User implements SiklidUserInterface, Authenticable, UserInterface, HasAcce
     /**
      * @return $this
      */
-    public function setEmail(string|Email $email): User
+    public function setEmail(Email $email): User
     {
-        $this->email = Email::fromString((string)$email);
+        $this->email = $email;
 
         return $this;
     }
@@ -103,9 +103,9 @@ class User implements SiklidUserInterface, Authenticable, UserInterface, HasAcce
     /**
      * @return $this
      */
-    public function setUsername(string|Username $username): User
+    public function setUsername(Username $username): User
     {
-        $this->username = Username::fromString((string)$username);
+        $this->username = $username;
 
         return $this;
     }

--- a/src/Siklid/Form/UserType.php
+++ b/src/Siklid/Form/UserType.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace App\Siklid\Form;
 
+use App\Foundation\ValueObject\Email;
+use App\Foundation\ValueObject\Username;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -17,5 +20,19 @@ class UserType extends AbstractType
         $builder->add('email', EmailType::class)
             ->add('password', PasswordType::class)
             ->add('username', TextType::class);
+
+        $builder->get('email')->addModelTransformer(
+            new CallbackTransformer(
+                static fn (?string $email) => is_null($email) ? null : Email::fromString($email),
+                static fn (string $email) => Email::fromString($email),
+            )
+        );
+
+        $builder->get('username')->addModelTransformer(
+            new CallbackTransformer(
+                static fn (?string $username) => is_null($username) ? null : Username::fromString($username),
+                static fn (string $username) => Username::fromString($username),
+            )
+        );
     }
 }

--- a/tests/Concerns/UserFactoryTrait.php
+++ b/tests/Concerns/UserFactoryTrait.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Tests\Concerns;
 
+use App\Foundation\ValueObject\Email;
+use App\Foundation\ValueObject\Username;
 use App\Siklid\Document\User;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
@@ -18,8 +20,8 @@ trait UserFactoryTrait
     {
         $user = new User();
 
-        $user->setEmail($attributes['email'] ?? $this->faker->email());
-        $user->setUsername($attributes['username'] ?? $this->faker()->userName());
+        $user->setEmail($attributes['email'] ?? Email::fromString($this->faker->email()));
+        $user->setUsername($attributes['username'] ?? Username::fromString($this->faker()->userName()));
         $user->setPassword($attributes['password'] ?? $this->faker()->password());
 
         /** @var UserPasswordHasherInterface $passwordHasher */

--- a/tests/Integration/Foundation/Security/Token/TokenManagerTest.php
+++ b/tests/Integration/Foundation/Security/Token/TokenManagerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Integration\Foundation\Security\Token;
 
 use App\Foundation\Security\Token\TokenManagerInterface;
+use App\Foundation\ValueObject\Email;
 use App\Siklid\Document\RefreshToken;
 use App\Siklid\Document\User;
 use App\Tests\IntegrationTestCase;
@@ -27,7 +28,7 @@ class TokenManagerTest extends IntegrationTestCase
         $user = new User();
 
         $email = $this->faker->email();
-        $user->setEmail($email);
+        $user->setEmail(Email::fromString($email));
 
         $sut = $container->get(TokenManagerInterface::class);
 

--- a/tests/Integration/Siklid/Command/SetupCommandTest.php
+++ b/tests/Integration/Siklid/Command/SetupCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Integration\Siklid\Command;
 
+use App\Foundation\ValueObject\Username;
 use App\Siklid\Document\User;
 use App\Tests\IntegrationTestCase;
 
@@ -22,8 +23,8 @@ class SetupCommandTest extends IntegrationTestCase
         $console->execute([]);
 
         $console->assertCommandIsSuccessful();
-        $this->assertExists(User::class, ['username' => 'admin']);
+        $this->assertExists(User::class, ['username' => Username::fromString('admin')]);
 
-        $this->deleteDocument(User::class, ['username' => 'admin']);
+        $this->deleteDocument(User::class, ['username' => Username::fromString('admin')]);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests;
 
 use App\Foundation\Util\Json;
+use Doctrine\ODM\MongoDB\Types\Type;
 
 /**
  * Class TestCase
@@ -25,5 +26,21 @@ class TestCase extends \PHPUnit\Framework\TestCase
         $this->faker = Faker::create();
 
         $this->json = new Json();
+    }
+
+    /**
+     * Creates an instance of the given mongo-odm custom type.
+     *
+     * @param class-string<T|Type> $type the type to create
+     *
+     * @return T
+     *
+     * @template T|Type
+     */
+    protected function createMongoType(string $type): Type
+    {
+        $type::registerType($type, $type);
+
+        return $type::getType($type);
     }
 }

--- a/tests/Unit/Foundation/ValueObject/UsernameTest.php
+++ b/tests/Unit/Foundation/ValueObject/UsernameTest.php
@@ -69,4 +69,16 @@ class UsernameTest extends TestCase
             ['imdhemy', '@imdhemy'],
         ];
     }
+
+    /**
+     * @test
+     */
+    public function equals(): void
+    {
+        $value = $this->faker->userName();
+        $obj1 = Username::fromString($value);
+        $obj2 = Username::fromString($value);
+
+        $this->assertTrue($obj1->equals($obj2));
+    }
 }

--- a/tests/Unit/Foundation/ValueType/EmailTypeTest.php
+++ b/tests/Unit/Foundation/ValueType/EmailTypeTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Foundation\ValueType;
+
+use App\Foundation\Exception\InvalidArgumentException;
+use App\Foundation\ValueObject\Email;
+use App\Foundation\ValueType\EmailType;
+use App\Tests\TestCase;
+
+class EmailTypeTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function convert_to_database_value(): void
+    {
+        $sut = $this->createMongoType(EmailType::class);
+        $email = $this->faker->email();
+
+        $actual = $sut->convertToDatabaseValue(Email::fromString($email));
+
+        $this->assertSame($email, $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function convert_to_database_value_accepts_only_email_value_object(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $sut = $this->createMongoType(EmailType::class);
+
+        $sut->convertToDatabaseValue($this->faker->email());
+    }
+
+    /**
+     * @test
+     */
+    public function null_value_should_be_skipped_by_doctrine(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $sut = $this->createMongoType(EmailType::class);
+
+        $sut->convertToPHPValue(null);
+    }
+
+    /**
+     * @test
+     */
+    public function convert_to_php_value(): void
+    {
+        $sut = $this->createMongoType(EmailType::class);
+        $email = $this->faker->email();
+
+        $actual = $sut->convertToPHPValue($email);
+
+        $this->assertTrue($actual->equals(Email::fromString($email)));
+    }
+}

--- a/tests/Unit/Foundation/ValueType/SlugTypeTest.php
+++ b/tests/Unit/Foundation/ValueType/SlugTypeTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Foundation\ValueType;
+
+use App\Foundation\Exception\InvalidArgumentException;
+use App\Foundation\ValueObject\Slug;
+use App\Foundation\ValueType\SlugType;
+use App\Tests\TestCase;
+
+class SlugTypeTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function convert_to_database_value(): void
+    {
+        $sut = $this->createMongoType(SlugType::class);
+
+        $this->assertSame('foo', $sut->convertToDatabaseValue(Slug::fromString('foo')));
+    }
+
+    /**
+     * @test
+     */
+    public function convert_to_db_value_process_only_slug_value_object(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $sut = $this->createMongoType(SlugType::class);
+
+        $sut->convertToDatabaseValue('foo');
+    }
+
+    /**
+     * @test
+     */
+    public function convert_to_php_value(): void
+    {
+        $sut = $this->createMongoType(SlugType::class);
+
+        $this->assertEquals(Slug::fromString('foo'), $sut->convertToPHPValue('foo'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_not_convert_null_db_values(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $sut = $this->createMongoType(SlugType::class);
+
+        $sut->convertToPHPValue(null);
+    }
+}

--- a/tests/Unit/Foundation/ValueType/SpecificTypeTest.php
+++ b/tests/Unit/Foundation/ValueType/SpecificTypeTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Foundation\ValueType;
+
+use App\Foundation\Exception\InvalidArgumentException;
+use App\Foundation\ValueType\CoercibleEnum;
+use App\Foundation\ValueType\SpecificType;
+use App\Tests\TestCase;
+
+class SpecificTypeTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function convert_to_db_value(): void
+    {
+        $sut = $this->createMongoType(SpecificType::class);
+        $coercibleEnum = MyCoercibleEnum::coerce('foo');
+
+        $actual = $sut->convertToDatabaseValue($coercibleEnum);
+
+        $this->assertSame(['name' => MyCoercibleEnum::class, 'value' => 'foo'], $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function convert_to_db_value_accepts_only_coercible_enum(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $sut = $this->createMongoType(SpecificType::class);
+        $nonCoercibleEnum = NonCoercibleEnum::from('foo');
+
+        $sut->convertToDatabaseValue($nonCoercibleEnum);
+    }
+
+    /**
+     * @test
+     */
+    public function convert_to_php_value(): void
+    {
+        $arr = ['name' => MyCoercibleEnum::class, 'value' => 'foo'];
+        $sut = $this->createMongoType(SpecificType::class);
+
+        $actual = $sut->convertToPHPValue($arr);
+
+        $this->assertInstanceOf(MyCoercibleEnum::class, $actual);
+        $this->assertSame('foo', $actual->value);
+    }
+
+    /**
+     * @test
+     */
+    public function value_key_is_required_to_convert_into_php_value(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $arr = ['name' => MyCoercibleEnum::class];
+        $sut = $this->createMongoType(SpecificType::class);
+
+        $sut->convertToPHPValue($arr);
+    }
+
+    /**
+     * @test
+     */
+    public function name_key_is_required_to_convert_into_php_value(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $arr = ['value' => 'foo'];
+        $sut = $this->createMongoType(SpecificType::class);
+
+        $sut->convertToPHPValue($arr);
+    }
+}
+
+enum MyCoercibleEnum: string implements CoercibleEnum
+{
+    case FOO = 'foo';
+
+    public static function coerce(mixed $value): CoercibleEnum
+    {
+        if ($value instanceof self) {
+            return $value;
+        }
+
+        return self::from((string)$value);
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'name' => self::class,
+            'value' => $this->value,
+        ];
+    }
+}
+
+enum NonCoercibleEnum: string
+{
+    case FOO = 'foo';
+    case BAR = 'bar';
+}

--- a/tests/Unit/Foundation/ValueType/UsernameTypeTest.php
+++ b/tests/Unit/Foundation/ValueType/UsernameTypeTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Foundation\ValueType;
+
+use App\Foundation\Exception\InvalidArgumentException;
+use App\Foundation\ValueObject\Username;
+use App\Foundation\ValueType\UsernameType;
+use App\Tests\TestCase;
+
+class UsernameTypeTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function convert_to_db_value_accepts_only_value_object(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $sut = $this->createMongoType(UsernameType::class);
+
+        $sut->convertToDatabaseValue('foo');
+    }
+
+    /**
+     * @test
+     */
+    public function null_value_should_be_skipped_by_doctrine(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $sut = $this->createMongoType(UsernameType::class);
+
+        $sut->convertToPHPValue(null);
+    }
+
+    /**
+     * @test
+     */
+    public function convert_to_db_value(): void
+    {
+        $sut = $this->createMongoType(UsernameType::class);
+        $username = Username::fromString('foo');
+
+        $actual = $sut->convertToDatabaseValue($username);
+
+        $this->assertSame('foo', $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function convert_to_php_value(): void
+    {
+        $sut = $this->createMongoType(UsernameType::class);
+
+        $actual = $sut->convertToPHPValue('foo');
+
+        $this->assertTrue($actual->equals(Username::fromString('foo')));
+    }
+}

--- a/tests/Unit/Siklid/Application/Auth/LoginSuccessHandlerTest.php
+++ b/tests/Unit/Siklid/Application/Auth/LoginSuccessHandlerTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Siklid\Application\Auth;
 
 use App\Foundation\Security\Token\TokenManagerInterface;
+use App\Foundation\ValueObject\Email;
+use App\Foundation\ValueObject\Username;
 use App\Siklid\Application\Auth\LoginSuccessHandler;
 use App\Siklid\Document\AccessToken;
 use App\Siklid\Document\User;
@@ -34,8 +36,8 @@ class LoginSuccessHandlerTest extends TestCase
 
         $user = new User();
         $user->setId($this->faker->uuid());
-        $user->setUsername($this->faker->userName());
-        $user->setEmail($this->faker->email());
+        $user->setUsername(Username::fromString($this->faker->userName()));
+        $user->setEmail(Email::fromString($this->faker->email()));
         $user->setAccessToken(
             new AccessToken($this->faker->md5())
         );
@@ -68,8 +70,8 @@ class LoginSuccessHandlerTest extends TestCase
 
         $user = new User();
         $user->setId($this->faker->uuid());
-        $user->setUsername($this->faker->userName());
-        $user->setEmail($this->faker->email());
+        $user->setUsername(Username::fromString($this->faker->userName()));
+        $user->setEmail(Email::fromString($this->faker->email()));
         $user->setAccessToken(
             new AccessToken($this->faker->md5())
         );


### PR DESCRIPTION
| Q             | A                                                                  |
|---------------|--------------------------------------------------------------------|
| Branch?       | 1.x <!-- see below -->                                             |
| Bug fix?      | yes                                                                |
| New feature?  | no <!-- please update /CHANGELOG.md files -->                      |
| Deprecations? | no <!-- please update UPGRADE-*.md and /CHANGELOG.md files -->     |
| Tickets       | Fix #65  <!-- prefix each issue number with "Fix #", -->           |
| License       | MIT                                                                |

This PR:

- adds a new test to check if custom types are correctly handled by the ODM. 
-  adds transformers for the `Email` and `Username` types.
- replaces all scalar-type arguments with value objects.
- Use `mixed` value for the Coercible enums (string is not enough for all backed enums).