### PR TITLE
[1.x] Fix serialization

### DIFF
--- a/config/packages/gesdinet_jwt_refresh_token.yaml
+++ b/config/packages/gesdinet_jwt_refresh_token.yaml
@@ -1,2 +1,3 @@
 gesdinet_jwt_refresh_token:
   refresh_token_class: App\Siklid\Document\RefreshToken
+  token_parameter_name: refreshToken

--- a/src/Controller/BoxController.php
+++ b/src/Controller/BoxController.php
@@ -17,7 +17,7 @@ class BoxController extends ApiController
     #[Route('/boxes', name: 'box_store', methods: ['POST'])]
     public function store(CreateBox $action): Response
     {
-        return $this->created($action->execute(), ['box:read']);
+        return $this->created($action->execute(), ['box:create']);
     }
 
     #[Route('/boxes/{id}', name: 'box_delete', methods: ['DELETE'])]

--- a/src/Controller/BoxController.php
+++ b/src/Controller/BoxController.php
@@ -24,6 +24,6 @@ class BoxController extends ApiController
     #[IsGranted('delete', subject: 'box')]
     public function delete(DeleteBox $action, Box $box): Response
     {
-        return $this->ok($action->setBox($box)->execute());
+        return $this->ok($action->setBox($box)->execute(), ['box:delete']);
     }
 }

--- a/src/Siklid/Document/Box.php
+++ b/src/Siklid/Document/Box.php
@@ -218,4 +218,10 @@ class Box implements BoxInterface
     {
         return null !== $this->deletedAt;
     }
+
+    #[MongoDB\PostLoad]
+    public function setClock(): void
+    {
+        $this->clock = SystemClock::fromSystemTimezone();
+    }
 }

--- a/src/Siklid/Document/Box.php
+++ b/src/Siklid/Document/Box.php
@@ -26,20 +26,20 @@ use Symfony\Component\Validator\Constraints as Assert;
 class Box implements BoxInterface
 {
     #[MongoDB\Id]
-    #[Groups(['box:read', 'box:delete'])]
+    #[Groups(['box:read', 'box:delete', 'box:create'])]
     private string $id;
 
     #[MongoDB\Field(type: 'string')]
     #[Assert\NotBlank]
-    #[Groups(['box:read'])]
+    #[Groups(['box:read', 'box:create'])]
     private string $name;
 
     #[MongoDB\Field(type: 'specific')]
-    #[Groups(['box:read'])]
+    #[Groups(['box:read', 'box:create'])]
     private RepetitionAlgorithm $repetitionAlgorithm = RepetitionAlgorithm::Leitner;
 
     #[MongoDB\Field(type: 'string', nullable: true)]
-    #[Groups(['box:read'])]
+    #[Groups(['box:read', 'box:create'])]
     private ?string $description = null;
 
     #[MongoDB\ReferenceMany(targetDocument: Flashcard::class)]
@@ -47,14 +47,15 @@ class Box implements BoxInterface
     private Collection $flashcards;
 
     #[MongoDB\Field(type: 'collection')]
-    #[Groups(['box:read'])]
+    #[Groups(['box:read', 'box:create'])]
     private array $hashtags = [];
 
     #[MongoDB\ReferenceOne(targetDocument: User::class)]
+    #[Groups(['box:read'])]
     private UserInterface $user;
 
     #[MongoDB\Field(type: 'date_immutable')]
-    #[Groups(['box:read'])]
+    #[Groups(['box:read', 'box:create'])]
     private DateTimeImmutable $createdAt;
 
     #[MongoDB\Field(type: 'date_immutable')]

--- a/src/Siklid/Document/Box.php
+++ b/src/Siklid/Document/Box.php
@@ -26,7 +26,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 class Box implements BoxInterface
 {
     #[MongoDB\Id]
-    #[Groups(['box:read'])]
+    #[Groups(['box:read', 'box:delete'])]
     private string $id;
 
     #[MongoDB\Field(type: 'string')]
@@ -62,7 +62,7 @@ class Box implements BoxInterface
     private DateTimeImmutable $updatedAt;
 
     #[MongoDB\Field(type: 'date_immutable', nullable: true)]
-    #[Groups(['box:read'])]
+    #[Groups(['box:read', 'box:delete'])]
     private ?DateTimeImmutable $deletedAt = null;
 
     private Clock $clock;

--- a/tests/Feature/Box/CreateBoxTest.php
+++ b/tests/Feature/Box/CreateBoxTest.php
@@ -37,11 +37,8 @@ class CreateBoxTest extends FeatureTestCase
                 'name',
                 'repetitionAlgorithm',
                 'description',
-                'flashcards',
                 'hashtags',
                 'createdAt',
-                'updatedAt',
-                'deletedAt',
             ],
         ]);
         $this->assertExists(Box::class, [


### PR DESCRIPTION
| Q             | A                                                                  |
|---------------|--------------------------------------------------------------------|
| Branch?       | 1.x <!-- see below -->                                             |
| Bug fix?      | yes                                                              |
| New feature?  |  no <!-- please update /CHANGELOG.md files -->                  |
| Deprecations? |  no <!-- please update UPGRADE-*.md and /CHANGELOG.md files --> |
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", -->           |
| License       | MIT                                                                |

This PR:

- Replaces the `refresh_token` param with a camel-case version to make it consistent across the projects.
- Injects a `Clock` instance into the `Box` after loading.
- Returns only the box `id` and `deletedAt` keys on the delete box response.
- Adds `box:create` serialization group