### PR TITLE
[1.x] Add cursor paginator

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -3,6 +3,9 @@
 
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
+imports:
+  - { resource: siklid.yaml }
+
 parameters:
   env(MONGODB_URL): ''
   env(MONGODB_DB): ''

--- a/config/siklid.yaml
+++ b/config/siklid.yaml
@@ -1,0 +1,4 @@
+parameters:
+  pagination:
+    limit: 25
+    max_limit: 100

--- a/psalm.xml
+++ b/psalm.xml
@@ -10,6 +10,7 @@
         <directory name="src"/>
         <ignoreFiles>
             <directory name="vendor"/>
+            <directory name="tests/Concerns"/>
         </ignoreFiles>
     </projectFiles>
     <plugins>

--- a/psalm.xml
+++ b/psalm.xml
@@ -10,7 +10,7 @@
         <directory name="src"/>
         <ignoreFiles>
             <directory name="vendor"/>
-            <directory name="tests/Concerns"/>
+            <directory name="tests/Concern"/>
         </ignoreFiles>
     </projectFiles>
     <plugins>

--- a/src/Foundation/Action/AbstractAction.php
+++ b/src/Foundation/Action/AbstractAction.php
@@ -36,4 +36,28 @@ abstract class AbstractAction extends AbstractController implements ActionInterf
             throw $validationException;
         }
     }
+
+    /**
+     * Returns the value of the given parameter.
+     *
+     * @return mixed The value of the parameter
+     *
+     * @psalm-suppress PossiblyUndefinedMethod - The user should know about the config values
+     * @psalm-suppress MixedAssignment - Expected to be mixed
+     */
+    public function getConfig(string $key, mixed $default = null): mixed
+    {
+        $keyParts = explode('.', $key);
+        $config = $this->getParameter($keyParts[0]);
+
+        foreach ($keyParts as $keyPart) {
+            if (! isset($config[$keyPart])) {
+                return $default;
+            }
+
+            $config = $config[$keyPart];
+        }
+
+        return $config ?? $default;
+    }
 }

--- a/src/Foundation/Http/ApiController.php
+++ b/src/Foundation/Http/ApiController.php
@@ -6,6 +6,7 @@ namespace App\Foundation\Http;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -43,5 +44,44 @@ abstract class ApiController extends AbstractController
     public function badRequest(mixed $body, array $headers = []): JsonResponse
     {
         return $this->json($body, Response::HTTP_BAD_REQUEST, $headers);
+    }
+
+    /**
+     * Returns a pagination JSON response with a 200 status code.
+     */
+    public function cursorPaginate(
+        array $data,
+        array $groups = [],
+        array $headers = [],
+        array $context = []
+    ): JsonResponse {
+        $context = array_replace_recursive($context, [
+            'groups' => $groups,
+        ]);
+
+        /** @var RequestStack $requestStack */
+        $requestStack = $this->container->get('request_stack');
+        /** @var \Symfony\Component\HttpFoundation\Request $request */
+        $request = $requestStack->getCurrentRequest();
+        $links = ['self' => $request->getUri(), 'next' => null];
+
+        /** @var string $cursorAccessor */
+        $cursorAccessor = $context['cursorAccessor'] ?? 'getId';
+        /** @var object|null $lastItem */
+        $lastItem = end($data);
+
+        if (is_object($lastItem) && method_exists($lastItem, $cursorAccessor)) {
+            $query = $request->query->all();
+            $query['cursor'] = (string)$lastItem->{$cursorAccessor}();
+            $links['next'] = $request->getSchemeAndHttpHost().$request->getPathInfo().'?'.http_build_query($query);
+        }
+
+        $body = [
+            'data' => $data,
+            'links' => $links,
+            'meta' => ['count' => count($data)],
+        ];
+
+        return $this->json($body, Response::HTTP_OK, $headers, $context);
     }
 }

--- a/src/Foundation/Http/ApiController.php
+++ b/src/Foundation/Http/ApiController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Foundation\Http;
 
+use App\Foundation\Pagination\Contract\PageInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -23,7 +24,9 @@ abstract class ApiController extends AbstractController
             'groups' => $groups,
         ]);
 
-        return $this->json(compact('data'), Response::HTTP_OK, $headers, $context);
+        $body = $data instanceof PageInterface ? $data : compact('data');
+
+        return $this->json($body, Response::HTTP_OK, $headers, $context);
     }
 
     /**

--- a/src/Foundation/Http/ApiController.php
+++ b/src/Foundation/Http/ApiController.php
@@ -7,7 +7,6 @@ namespace App\Foundation\Http;
 use App\Foundation\Pagination\Contract\PageInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -47,44 +46,5 @@ abstract class ApiController extends AbstractController
     public function badRequest(mixed $body, array $headers = []): JsonResponse
     {
         return $this->json($body, Response::HTTP_BAD_REQUEST, $headers);
-    }
-
-    /**
-     * Returns a pagination JSON response with a 200 status code.
-     */
-    public function cursorPaginate(
-        array $data,
-        array $groups = [],
-        array $headers = [],
-        array $context = []
-    ): JsonResponse {
-        $context = array_replace_recursive($context, [
-            'groups' => $groups,
-        ]);
-
-        /** @var RequestStack $requestStack */
-        $requestStack = $this->container->get('request_stack');
-        /** @var \Symfony\Component\HttpFoundation\Request $request */
-        $request = $requestStack->getCurrentRequest();
-        $links = ['self' => $request->getUri(), 'next' => null];
-
-        /** @var string $cursorAccessor */
-        $cursorAccessor = $context['cursorAccessor'] ?? 'getId';
-        /** @var object|null $lastItem */
-        $lastItem = end($data);
-
-        if (is_object($lastItem) && method_exists($lastItem, $cursorAccessor)) {
-            $query = $request->query->all();
-            $query['cursor'] = (string)$lastItem->{$cursorAccessor}();
-            $links['next'] = $request->getSchemeAndHttpHost().$request->getPathInfo().'?'.http_build_query($query);
-        }
-
-        $body = [
-            'data' => $data,
-            'links' => $links,
-            'meta' => ['count' => count($data)],
-        ];
-
-        return $this->json($body, Response::HTTP_OK, $headers, $context);
     }
 }

--- a/src/Foundation/Http/Request.php
+++ b/src/Foundation/Http/Request.php
@@ -62,4 +62,23 @@ class Request implements ValidatableInterface
     {
         return $this->all();
     }
+
+    /**
+     * Retrieves $_GET and $_POST variables respectively.
+     */
+    public function get(string $key, string $default = ''): string|int|float|bool|null
+    {
+        $getVariables = $this->request()->query;
+        $postVariables = $this->request()->request;
+
+        if ($getVariables->has($key)) {
+            return $getVariables->get($key, $default);
+        }
+
+        if ($postVariables->has($key)) {
+            return $postVariables->get($key, $default);
+        }
+
+        return $default;
+    }
 }

--- a/src/Foundation/Http/Request.php
+++ b/src/Foundation/Http/Request.php
@@ -66,12 +66,16 @@ class Request implements ValidatableInterface
     /**
      * Retrieves $_GET and $_POST variables respectively.
      */
-    public function get(string $key, string $default = ''): string|int|float|bool|null
+    public function get(string $key, mixed $default = null): string|int|bool|null|float
     {
+        assert(is_scalar($default) || is_null($default));
+
         $getVariables = $this->request()->query;
         $postVariables = $this->request()->request;
 
         if ($getVariables->has($key)) {
+            assert(is_string($default) || is_null($default));
+
             return $getVariables->get($key, $default);
         }
 

--- a/src/Foundation/Pagination/Contract/PageInterface.php
+++ b/src/Foundation/Pagination/Contract/PageInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Foundation\Pagination\Contract;
+
+/**
+ * Objects implementing this interface represent a single page of a paginated collection.
+ */
+interface PageInterface
+{
+    public function getData(): array;
+
+    public function getLinks(): array;
+
+    public function getMeta(): array;
+}

--- a/src/Foundation/Pagination/Contract/PaginatorInterface.php
+++ b/src/Foundation/Pagination/Contract/PaginatorInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Foundation\Pagination\Contract;
+
+use Doctrine\ODM\MongoDB\Query\Builder;
+
+/**
+ * All pagination classes must implement this interface.
+ */
+interface PaginatorInterface
+{
+    public function paginate(Builder $builder, string $offset, int $limit): PageInterface;
+}

--- a/src/Foundation/Pagination/CursorPaginator.php
+++ b/src/Foundation/Pagination/CursorPaginator.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Foundation\Pagination;
+
+use App\Foundation\Pagination\Contract\PageInterface;
+use App\Foundation\Pagination\Contract\PaginatorInterface;
+use Doctrine\ODM\MongoDB\Query\Builder;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Cursor paginator uses a cursor to paginate through a list of items.
+ * The cursor is a string that represents the last item of the previous page.
+ */
+final class CursorPaginator implements PaginatorInterface
+{
+    private Request $request;
+
+    public function __construct(Request $request)
+    {
+        $this->request = $request;
+    }
+
+    public static function create(?Request $request = null): self
+    {
+        return new self($request ?? Request::createFromGlobals());
+    }
+
+    /**
+     * Paginates a query builder.
+     *
+     * @param builder $builder - The query builder to paginate
+     * @param string $offset   - Used as the cursor
+     * @param int $limit       - The number of items to return per page
+     *
+     * @return pageInterface - The paginated page
+     */
+    public function paginate(Builder $builder, string $offset = '', int $limit = 25): PageInterface
+    {
+        $cursor = empty($offset) ? (string)$this->request->query->get('after') : $offset;
+
+        if (! empty($cursor)) {
+            $builder->field('id')->lt($cursor);
+        }
+
+        $builder->limit($limit);
+
+        $data = $builder->getQuery()->toArray();
+        $links = $this->buildLinks($data);
+        $meta = ['perPage' => $limit, 'count' => count($data)];
+
+        return Page::init()->data($data)->links($links)->meta($meta);
+    }
+
+    private function buildLinks(array $data): array
+    {
+        $next = null;
+
+        /** @var object|null $lastItem */
+        $lastItem = end($data);
+        if (is_object($lastItem) && method_exists($lastItem, 'getId')) {
+            $lastItemCursor = (string)$lastItem->getId();
+            $query = $this->request->query->all();
+            $query['after'] = $lastItemCursor;
+            $next = $this->request->getUriForPath($this->request->getPathInfo()).'?'.http_build_query($query);
+        }
+
+        return [
+            'self' => $this->request->getUri(),
+            'next' => $next,
+        ];
+    }
+}

--- a/src/Foundation/Pagination/CursorPaginator.php
+++ b/src/Foundation/Pagination/CursorPaginator.php
@@ -31,8 +31,8 @@ final class CursorPaginator implements PaginatorInterface
      * Paginates a query builder.
      *
      * @param builder $builder - The query builder to paginate
-     * @param string $offset   - Used as the cursor
-     * @param int $limit       - The number of items to return per page
+     * @param string  $offset  - Used as the cursor
+     * @param int     $limit   - The number of items to return per page
      *
      * @return pageInterface - The paginated page
      */

--- a/src/Foundation/Pagination/Page.php
+++ b/src/Foundation/Pagination/Page.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Foundation\Pagination;
+
+use App\Foundation\Pagination\Contract\PageInterface;
+use JsonSerializable;
+
+final class Page implements PageInterface, JsonSerializable
+{
+    private array $data = [];
+
+    private array $links = [];
+
+    private array $meta = [];
+
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
+    public function getLinks(): array
+    {
+        return $this->links;
+    }
+
+    public function getMeta(): array
+    {
+        return $this->meta;
+    }
+
+    public static function init(): self
+    {
+        return new self();
+    }
+
+    public function data(array $data): self
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
+    public function links(array $links): self
+    {
+        $this->links = $links;
+
+        return $this;
+    }
+
+    public function meta(array $meta): self
+    {
+        $this->meta = $meta;
+
+        return $this;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'data' => $this->data,
+            'meta' => $this->meta,
+            'links' => $this->links,
+        ];
+    }
+}

--- a/src/Foundation/Pagination/Page.php
+++ b/src/Foundation/Pagination/Page.php
@@ -7,8 +7,14 @@ namespace App\Foundation\Pagination;
 use App\Foundation\Pagination\Contract\PageInterface;
 use JsonSerializable;
 
+/**
+ * @template T The type of the elements of the page.
+ */
 final class Page implements PageInterface, JsonSerializable
 {
+    /**
+     * @var array|T[] the elements of the page
+     */
     private array $data = [];
 
     private array $links = [];
@@ -35,6 +41,11 @@ final class Page implements PageInterface, JsonSerializable
         return new self();
     }
 
+    /**
+     * @param array|T[] $data
+     *
+     * @return $this
+     */
     public function data(array $data): self
     {
         $this->data = $data;

--- a/tests/Concern/BoxFactoryTrait.php
+++ b/tests/Concern/BoxFactoryTrait.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Concerns;
+namespace App\Tests\Concern;
 
 use App\Siklid\Document\Box;
 use App\Siklid\Document\User;

--- a/tests/Concern/DBTrait.php
+++ b/tests/Concern/DBTrait.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Concerns;
+namespace App\Tests\Concern;
 
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;

--- a/tests/Concern/FactoryConcern.php
+++ b/tests/Concern/FactoryConcern.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Concerns;
+namespace App\Tests\Concern;
 
 use App\Tests\Faker;
 use Symfony\Component\DependencyInjection\ContainerInterface;

--- a/tests/Concern/UserFactoryTrait.php
+++ b/tests/Concern/UserFactoryTrait.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Concerns;
+namespace App\Tests\Concern;
 
 use App\Foundation\ValueObject\Email;
 use App\Foundation\ValueObject\Username;

--- a/tests/Feature/Auth/EmailAuthTest.php
+++ b/tests/Feature/Auth/EmailAuthTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Feature\Auth;
 
 use App\Foundation\ValueObject\Email;
 use App\Foundation\ValueObject\Username;
+use App\Siklid\Document\RefreshToken;
 use App\Siklid\Document\User;
 use App\Tests\FeatureTestCase;
 
@@ -48,6 +49,8 @@ class EmailAuthTest extends FeatureTestCase
             'email' => $email,
             'username' => $username,
         ]);
+
+        $this->deleteDocument(RefreshToken::class, ['username' => $email]);
     }
 
     /**
@@ -83,5 +86,6 @@ class EmailAuthTest extends FeatureTestCase
         ]);
 
         $this->deleteDocument(User::class, ['email' => $email]);
+        $this->deleteDocument(RefreshToken::class, ['username' => $user->getUserIdentifier()]);
     }
 }

--- a/tests/Feature/Box/DeleteBoxTest.php
+++ b/tests/Feature/Box/DeleteBoxTest.php
@@ -68,5 +68,8 @@ class DeleteBoxTest extends FeatureTestCase
         $client->request('DELETE', 'api/v1/boxes/'.$box->getId());
 
         $this->assertResponseIsForbidden();
+
+        $this->deleteDocument($user);
+        $this->deleteDocument($box);
     }
 }

--- a/tests/Feature/Box/DeleteBoxTest.php
+++ b/tests/Feature/Box/DeleteBoxTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Feature\Box;
 
 use App\Siklid\Document\Box;
-use App\Tests\Concerns\BoxFactoryTrait;
+use App\Tests\Concern\BoxFactoryTrait;
 use App\Tests\FeatureTestCase;
 
 /**

--- a/tests/FeatureTestCase.php
+++ b/tests/FeatureTestCase.php
@@ -138,11 +138,11 @@ class FeatureTestCase extends WebTestCase
     protected function assertStructure(array $content, array $structure): void
     {
         foreach ($structure as $key => $value) {
-            if (is_int($key)) {
-                $this->assertArrayHasKey($value, $content);
-            } else {
+            if (is_array($value)) {
                 $this->assertArrayHasKey($key, $content);
                 $this->assertStructure($content[$key], $value);
+            } else {
+                $this->assertArrayHasKey($value, $content);
             }
         }
     }

--- a/tests/FeatureTestCase.php
+++ b/tests/FeatureTestCase.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace App\Tests;
 
 use App\Foundation\Util\Json;
-use App\Tests\Concerns\DBTrait;
-use App\Tests\Concerns\UserFactoryTrait;
+use App\Tests\Concern\DBTrait;
+use App\Tests\Concern\UserFactoryTrait;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;

--- a/tests/Integration/Foundation/Pagination/CursorPaginatorTest.php
+++ b/tests/Integration/Foundation/Pagination/CursorPaginatorTest.php
@@ -6,7 +6,7 @@ namespace App\Tests\Integration\Foundation\Pagination;
 
 use App\Foundation\Pagination\CursorPaginator;
 use App\Siklid\Document\User;
-use App\Tests\Concerns\UserFactoryTrait;
+use App\Tests\Concern\UserFactoryTrait;
 use App\Tests\IntegrationTestCase;
 use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\Request;

--- a/tests/Integration/Foundation/Pagination/CursorPaginatorTest.php
+++ b/tests/Integration/Foundation/Pagination/CursorPaginatorTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Foundation\Pagination;
+
+use App\Foundation\Pagination\CursorPaginator;
+use App\Siklid\Document\User;
+use App\Tests\Concerns\UserFactoryTrait;
+use App\Tests\IntegrationTestCase;
+use Symfony\Component\HttpFoundation\InputBag;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @psalm-suppress MissingConstructor
+ */
+class CursorPaginatorTest extends IntegrationTestCase
+{
+    use UserFactoryTrait;
+
+    /**
+     * @var User[]
+     */
+    private array $users = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $documentManager = $this->getDocumentManager();
+        for ($i = 0; $i < 3; ++$i) {
+            $user = $this->makeUser();
+            $documentManager->persist($user);
+            $this->users[] = $user;
+        }
+        $documentManager->flush();
+    }
+
+    /**
+     * @test
+     */
+    public function paginate_limit(): void
+    {
+        $sut = $this->createSut();
+        $documentManager = $this->getDocumentManager();
+        $builder = $documentManager->createQueryBuilder(User::class);
+
+        $actual = $sut->paginate($builder, '', 1);
+
+        /** @var User[] $data */
+        $data = $actual->getData();
+        $this->assertCount(1, $data);
+        $this->assertSame($this->users[0], $data[0]);
+    }
+
+    /**
+     * @test
+     */
+    public function paginate_after(): void
+    {
+        $sut = $this->createSut();
+        $documentManager = $this->getDocumentManager();
+        $builder = $documentManager->createQueryBuilder(User::class);
+        $builder->sort('id', 'desc');
+        $actual = $sut->paginate($builder, $this->users[2]->getId(), 1);
+
+        /** @var User[] $data */
+        $data = $actual->getData();
+        $this->assertCount(1, $data);
+        $this->assertSame($this->users[1], $data[0]);
+    }
+
+    /**
+     * @test
+     */
+    public function paginate_can_get_after_offset_from_request(): void
+    {
+        $sut = $this->createSut(['after' => $this->users[2]->getId()]);
+        $documentManager = $this->getDocumentManager();
+        $builder = $documentManager->createQueryBuilder(User::class);
+        $builder->sort('id', 'desc');
+        $actual = $sut->paginate($builder, '', 1);
+
+        /** @var User[] $data */
+        $data = $actual->getData();
+        $this->assertCount(1, $data);
+        $this->assertSame($this->users[1], $data[0]);
+    }
+
+    /**
+     * @test
+     */
+    public function page_links(): void
+    {
+        $sut = $this->createSut();
+        $documentManager = $this->getDocumentManager();
+        $builder = $documentManager->createQueryBuilder(User::class);
+        $actual = $sut->paginate($builder, '', 1);
+
+        $links = $actual->getLinks();
+        $this->assertArrayHasKey('next', $links);
+        $this->assertArrayHasKey('self', $links);
+        $this->assertSame('https://localhost?after='.$this->users[0]->getId(), $links['next']);
+        $this->assertSame('https://localhost?after=', $links['self']);
+    }
+
+    /**
+     * @test
+     */
+    public function page_meta(): void
+    {
+        $sut = $this->createSut();
+        $documentManager = $this->getDocumentManager();
+        $builder = $documentManager->createQueryBuilder(User::class);
+        $actual = $sut->paginate($builder, '', 7);
+
+        $meta = $actual->getMeta();
+        $this->assertSame(count($this->users), $meta['count']);
+        $this->assertSame(7, $meta['perPage']);
+    }
+
+    protected function tearDown(): void
+    {
+        $documentManager = $this->getDocumentManager();
+        foreach ($this->users as $user) {
+            $documentManager->remove($user);
+        }
+        $documentManager->flush();
+        parent::tearDown();
+    }
+
+    /**
+     * @param array<string, string> $params
+     *
+     * @psalm-suppress InvalidPropertyAssignmentValue - $request->query has the right type.
+     */
+    private function createSut(array $params = []): CursorPaginator
+    {
+        $request = $this->createMock(Request::class);
+        $request->expects($this->once())->method('getUri')->willReturn('https://localhost?after=');
+        $request->expects($this->once())->method('getUriForPath')->willReturn('https://localhost');
+        $request->query = new InputBag();
+        foreach ($params as $key => $value) {
+            $request->query->set($key, $value);
+        }
+
+        return CursorPaginator::create($request);
+    }
+}

--- a/tests/Integration/Foundation/Pagination/CursorPaginatorTest.php
+++ b/tests/Integration/Foundation/Pagination/CursorPaginatorTest.php
@@ -47,7 +47,6 @@ class CursorPaginatorTest extends IntegrationTestCase
 
         $actual = $sut->paginate($builder, '', 1);
 
-        /** @var User[] $data */
         $data = $actual->getData();
         $this->assertCount(1, $data);
         $this->assertSame($this->users[0], $data[0]);
@@ -64,7 +63,6 @@ class CursorPaginatorTest extends IntegrationTestCase
         $builder->sort('id', 'desc');
         $actual = $sut->paginate($builder, $this->users[2]->getId(), 1);
 
-        /** @var User[] $data */
         $data = $actual->getData();
         $this->assertCount(1, $data);
         $this->assertSame($this->users[1], $data[0]);
@@ -80,8 +78,7 @@ class CursorPaginatorTest extends IntegrationTestCase
         $builder = $documentManager->createQueryBuilder(User::class);
         $builder->sort('id', 'desc');
         $actual = $sut->paginate($builder, '', 1);
-
-        /** @var User[] $data */
+        
         $data = $actual->getData();
         $this->assertCount(1, $data);
         $this->assertSame($this->users[1], $data[0]);

--- a/tests/Integration/Foundation/Pagination/CursorPaginatorTest.php
+++ b/tests/Integration/Foundation/Pagination/CursorPaginatorTest.php
@@ -78,7 +78,7 @@ class CursorPaginatorTest extends IntegrationTestCase
         $builder = $documentManager->createQueryBuilder(User::class);
         $builder->sort('id', 'desc');
         $actual = $sut->paginate($builder, '', 1);
-        
+
         $data = $actual->getData();
         $this->assertCount(1, $data);
         $this->assertSame($this->users[1], $data[0]);

--- a/tests/Integration/Foundation/Security/Token/TokenManagerTest.php
+++ b/tests/Integration/Foundation/Security/Token/TokenManagerTest.php
@@ -24,16 +24,16 @@ class TokenManagerTest extends IntegrationTestCase
     public function create_access_token(): void
     {
         $container = $this->container();
-
         $user = new User();
-
         $email = $this->faker->email();
         $user->setEmail(Email::fromString($email));
-
         $sut = $container->get(TokenManagerInterface::class);
 
         $accessToken = $sut->createAccessToken($user);
+
         $this->assertNotNull($accessToken->getToken());
-        $this->assertExists(RefreshToken::class, ['username' => $user->getEmail()]);
+        $this->assertExists(RefreshToken::class, ['username' => $user->getUserIdentifier()]);
+
+        $this->deleteDocument(RefreshToken::class, ['username' => $user->getUserIdentifier()]);
     }
 }

--- a/tests/IntegrationTestCase.php
+++ b/tests/IntegrationTestCase.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Tests;
 
 use App\Foundation\Util\Json;
-use App\Tests\Concerns\DBTrait;
+use App\Tests\Concern\DBTrait;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Command\Command;
@@ -61,8 +61,8 @@ class IntegrationTestCase extends KernelTestCase
     /**
      * Creates a command tester.
      *
-     * @param Application    $application The console application
-     * @param string|Command $command     The command to test
+     * @param Application $application The console application
+     * @param string|Command $command  The command to test
      */
     protected function cmdTester(Application $application, string|Command $command): CommandTester
     {

--- a/tests/IntegrationTestCase.php
+++ b/tests/IntegrationTestCase.php
@@ -61,8 +61,8 @@ class IntegrationTestCase extends KernelTestCase
     /**
      * Creates a command tester.
      *
-     * @param Application $application The console application
-     * @param string|Command $command  The command to test
+     * @param Application    $application The console application
+     * @param string|Command $command     The command to test
      */
     protected function cmdTester(Application $application, string|Command $command): CommandTester
     {

--- a/tests/IntegrationTestCase.php
+++ b/tests/IntegrationTestCase.php
@@ -70,4 +70,9 @@ class IntegrationTestCase extends KernelTestCase
 
         return new CommandTester($command);
     }
+
+    protected function faker(): Faker
+    {
+        return $this->faker;
+    }
 }

--- a/tests/Unit/Foundation/Action/AbstractionActionTest.php
+++ b/tests/Unit/Foundation/Action/AbstractionActionTest.php
@@ -8,6 +8,8 @@ use App\Foundation\Action\AbstractAction;
 use App\Foundation\Action\ValidatableInterface;
 use App\Foundation\Exception\ValidationException;
 use App\Tests\TestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\Form\FormInterface;
 
 /**
@@ -52,5 +54,46 @@ class AbstractionActionTest extends TestCase
         $sut = $this->getMockForAbstractClass(AbstractAction::class);
 
         $sut->validate($form, $this->request);
+    }
+
+    /**
+     * @test
+     */
+    public function get_config(): AbstractAction
+    {
+        $sut = $this->getMockForAbstractClass(AbstractAction::class);
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('has')->willReturn(true);
+        $parameterBag = $this->createMock(ParameterBag::class);
+        $parameterBag->method('get')->willReturn(['foo' => ['bar' => 'baz']]);
+        $container->method('get')->willReturn($parameterBag);
+
+        $sut->setContainer($container);
+
+        $this->assertSame('baz', $sut->getConfig('foo.bar'));
+        $this->assertSame(['bar' => 'baz'], $sut->getConfig('foo'));
+        $this->assertNull($sut->getConfig('missing'));
+
+        return $sut;
+    }
+
+    /**
+     * @test
+     *
+     * @depends get_config
+     */
+    public function get_config_returns_null_by_default(AbstractAction $sut): void
+    {
+        $this->assertNull($sut->getConfig('foo.missing'));
+    }
+
+    /**
+     * @test
+     *
+     * @depends get_config
+     */
+    public function get_config_can_accept_a_default_value(AbstractAction $sut): void
+    {
+        $this->assertSame('default', $sut->getConfig('foo.missing', 'default'));
     }
 }

--- a/tests/Unit/Foundation/Http/ApiControllerTest.php
+++ b/tests/Unit/Foundation/Http/ApiControllerTest.php
@@ -60,7 +60,7 @@ class ApiControllerTest extends TestCase
         return [
             'null' => [null, ['data' => null]],
             'array' => [['foo' => 'bar'], ['data' => ['foo' => 'bar']]],
-            'page' => [Page::init()->data(['foo' => 'bar']), ['data' => ['foo' => 'bar'], 'links' => [], 'meta' => []]],
+            'page' => [Page::init()->data(['foo' => 'bar']), ['data' => ['foo' => 'bar'], 'meta' => [], 'links' => []]],
         ];
     }
 }

--- a/tests/Unit/Foundation/Http/ApiControllerTest.php
+++ b/tests/Unit/Foundation/Http/ApiControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Foundation\Http;
 
 use App\Foundation\Http\ApiController;
+use App\Foundation\Pagination\Page;
 use App\Tests\TestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
@@ -26,16 +27,15 @@ class ApiControllerTest extends TestCase
 
     /**
      * @test
+     *
+     * @dataProvider provideResponsesForOk
      */
-    public function ok(): void
+    public function ok(mixed $data, array $expected): void
     {
-        $data = ['foo' => 'bar'];
-
         $actual = $this->sut->ok($data);
-
         $this->assertSame(Response::HTTP_OK, $actual->getStatusCode());
         $content = $this->json->jsonToArray((string)$actual->getContent());
-        $this->assertSame($data, $content['data']);
+        $this->assertSame($content, $expected);
     }
 
     /**
@@ -50,5 +50,17 @@ class ApiControllerTest extends TestCase
         $this->assertSame(Response::HTTP_CREATED, $actual->getStatusCode());
         $content = $this->json->jsonToArray((string)$actual->getContent());
         $this->assertSame($data, $content['data']);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideResponsesForOk(): array
+    {
+        return [
+            'null' => [null, ['data' => null]],
+            'array' => [['foo' => 'bar'], ['data' => ['foo' => 'bar']]],
+            'page' => [Page::init()->data(['foo' => 'bar']), ['data' => ['foo' => 'bar'], 'links' => [], 'meta' => []]],
+        ];
     }
 }

--- a/tests/Unit/Foundation/Http/RequestTest.php
+++ b/tests/Unit/Foundation/Http/RequestTest.php
@@ -112,4 +112,43 @@ class RequestTest extends TestCase
 
         $this->assertSame($sut->all(), $sut->formInput());
     }
+
+    /**
+     * @test
+     */
+    public function get_returns_get_variables(): void
+    {
+        $sut = new Sut($this->requestStack, $this->util);
+        $this->requestStack->push(new Request(['foo' => 'bar']));
+
+        $actual = $sut->get('foo');
+
+        $this->assertSame('bar', $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function get_returns_post_variables(): void
+    {
+        $sut = new Sut($this->requestStack, $this->util);
+        $this->requestStack->push(new Request([], ['foo' => 'bar']));
+
+        $actual = $sut->get('foo');
+
+        $this->assertSame('bar', $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function get_can_return_a_default_value(): void
+    {
+        $sut = new Sut($this->requestStack, $this->util);
+        $this->requestStack->push(new Request());
+
+        $actual = $sut->get('foo', 'bar');
+
+        $this->assertSame('bar', $actual);
+    }
 }

--- a/tests/Unit/Foundation/Pagination/PageTest.php
+++ b/tests/Unit/Foundation/Pagination/PageTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Foundation\Pagination;
+
+use App\Foundation\Pagination\Page;
+use App\Tests\TestCase;
+
+/**
+ * @psalm-suppress MissingConstructor
+ */
+class PageTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function get_data(): void
+    {
+        $sut = new Page();
+        $sut->data(['foo' => 'bar']);
+
+        $actual = $sut->getData();
+
+        $this->assertSame(['foo' => 'bar'], $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function get_meta(): void
+    {
+        $sut = new Page();
+        $sut->meta(['count' => 99]);
+
+        $actual = $sut->getMeta();
+
+        $this->assertSame(['count' => 99], $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function get_links(): void
+    {
+        $sut = new Page();
+        $sut->links(['self' => 'https://example.com']);
+
+        $actual = $sut->getLinks();
+
+        $this->assertSame(['self' => 'https://example.com'], $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function json_serialize(): void
+    {
+        $sut = Page::init()->data(['foo' => 'bar'])->meta(['count' => 99])->links(['self' => 'https://example.com']);
+
+        $actual = $sut->jsonSerialize();
+
+        $this->assertSame(
+            ['data' => ['foo' => 'bar'], 'meta' => ['count' => 99], 'links' => ['self' => 'https://example.com']],
+            $actual
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A                                                                  |
|---------------|--------------------------------------------------------------------|
| Branch?       | 1.x <!-- see below -->                                             |
| Bug fix?      | yes/no                                                             |
| New feature?  | yes/no <!-- please update /CHANGELOG.md files -->                  |
| Deprecations? | yes/no <!-- please update UPGRADE-*.md and /CHANGELOG.md files --> |
| Tickets       | Fix #122  <!-- prefix each issue number with "Fix #", -->           |
| License       | MIT                                                                |

This PR adds a simple cursor paginator that supports the `after` cursor.
