### PR TITLE
[1.x] List boxes

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -46,6 +46,7 @@ security:
     # - { path: ^/admin, roles: ROLE_ADMIN }
     # - { path: ^/profile, roles: ROLE_USER }
     - { path: ^/api/v1/auth/(register|login|token), roles: PUBLIC_ACCESS }
+    - { path: ^/api/v1/boxes, roles: PUBLIC_ACCESS, methods: [ GET ] }
     - { path: ^/api,       roles: IS_AUTHENTICATED_FULLY }
 
 when@test:

--- a/src/Controller/BoxController.php
+++ b/src/Controller/BoxController.php
@@ -7,6 +7,7 @@ namespace App\Controller;
 use App\Foundation\Http\ApiController;
 use App\Siklid\Application\Box\CreateBox;
 use App\Siklid\Application\Box\DeleteBox;
+use App\Siklid\Application\Box\ListBoxes;
 use App\Siklid\Document\Box;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
 use Symfony\Component\HttpFoundation\Response;
@@ -25,5 +26,11 @@ class BoxController extends ApiController
     public function delete(DeleteBox $action, Box $box): Response
     {
         return $this->ok($action->setBox($box)->execute(), ['box:delete']);
+    }
+
+    #[Route('/boxes', name: 'box_index', methods: ['GET'])]
+    public function index(ListBoxes $action): Response
+    {
+        return $this->ok($action->execute(), ['box:index', 'resource:read']);
     }
 }

--- a/src/Foundation/Http/Request.php
+++ b/src/Foundation/Http/Request.php
@@ -85,4 +85,12 @@ class Request implements ValidatableInterface
 
         return $default;
     }
+
+    /**
+     * Checks if request has a given parameter.
+     */
+    public function has(string $key): bool
+    {
+        return $this->request()->query->has($key) || $this->request()->request->has($key);
+    }
 }

--- a/src/Siklid/Application/Box/ListBoxes.php
+++ b/src/Siklid/Application/Box/ListBoxes.php
@@ -32,8 +32,12 @@ final class ListBoxes extends AbstractAction
         assert($boxRepository instanceof BoxRepository);
 
         $after = (string)$this->request->get('after');
+        $hashtag = $this->request->get('hashtag');
+        if (null !== $hashtag) {
+            $hashtag = (string)$hashtag;
+        }
         $limit = (int)$this->getConfig('pagination.limit', 25);
 
-        return $boxRepository->PaginateAfter($after, $limit);
+        return $boxRepository->PaginateAfter($after, $hashtag, $limit);
     }
 }

--- a/src/Siklid/Application/Box/ListBoxes.php
+++ b/src/Siklid/Application/Box/ListBoxes.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Siklid\Application\Box;
 
 use App\Foundation\Action\AbstractAction;
+use App\Foundation\Exception\ValidationException;
 use App\Foundation\Http\Request;
 use App\Foundation\Pagination\Contract\PageInterface;
 use App\Siklid\Document\Box;
@@ -39,8 +40,21 @@ final class ListBoxes extends AbstractAction
         $limit = (int)$this->getConfig('pagination.limit', 25);
         if ($this->request->has('size')) {
             $limit = (int)$this->request->get('size');
+            $this->validateSize($limit);
         }
 
         return $boxRepository->PaginateAfter($after, $hashtag, $limit);
+    }
+
+    private function validateSize(int $limit): void
+    {
+        if ($limit < 1) {
+            throw new ValidationException('Size must be 1 or greater.');
+        }
+
+        $maxSize = (int)$this->getConfig('pagination.max_limit', 100);
+        if ($limit > $maxSize) {
+            throw new ValidationException("Size must be less than or equal to $maxSize.");
+        }
     }
 }

--- a/src/Siklid/Application/Box/ListBoxes.php
+++ b/src/Siklid/Application/Box/ListBoxes.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Siklid\Application\Box;
+
+use App\Foundation\Action\AbstractAction;
+use App\Foundation\Http\Request;
+use App\Foundation\Pagination\Contract\PageInterface;
+use App\Siklid\Document\Box;
+use App\Siklid\Repository\BoxRepository;
+use Doctrine\ODM\MongoDB\DocumentManager;
+
+/**
+ * This action is used to list all boxes.
+ */
+final class ListBoxes extends AbstractAction
+{
+    private DocumentManager $dm;
+
+    private Request $request;
+
+    public function __construct(DocumentManager $dm, Request $request)
+    {
+        $this->dm = $dm;
+        $this->request = $request;
+    }
+
+    public function execute(): PageInterface
+    {
+        $boxRepository = $this->dm->getRepository(Box::class);
+        assert($boxRepository instanceof BoxRepository);
+
+        $after = (string)$this->request->get('after');
+        $limit = (int)$this->getConfig('pagination.limit', 25);
+
+        return $boxRepository->PaginateAfter($after, $limit);
+    }
+}

--- a/src/Siklid/Application/Box/ListBoxes.php
+++ b/src/Siklid/Application/Box/ListBoxes.php
@@ -51,22 +51,23 @@ final class ListBoxes extends AbstractAction
         }
     }
 
-    public function getAfterCursor(): string
+    private function getAfterCursor(): string
     {
         return (string)$this->request->get('after');
     }
 
-    public function getHashtag(): ?string
+    private function getHashtag(): ?string
     {
         $hashtag = $this->request->get('hashtag');
-        if (null !== $hashtag) {
-            $hashtag = empty($hashtag) ? null : (string)$hashtag;
+
+        if (empty($hashtag)) {
+            return null;
         }
 
-        return $hashtag;
+        return '#'.$hashtag;
     }
 
-    public function getLimit(): int
+    private function getLimit(): int
     {
         $limit = (int)$this->getConfig('pagination.limit', 25);
 

--- a/src/Siklid/Application/Box/ListBoxes.php
+++ b/src/Siklid/Application/Box/ListBoxes.php
@@ -35,7 +35,7 @@ final class ListBoxes extends AbstractAction
         $after = (string)$this->request->get('after');
         $hashtag = $this->request->get('hashtag');
         if (null !== $hashtag) {
-            $hashtag = (string)$hashtag;
+            $hashtag = empty($hashtag) ? null : (string)$hashtag;
         }
         $limit = (int)$this->getConfig('pagination.limit', 25);
         if ($this->request->has('size')) {

--- a/src/Siklid/Application/Box/ListBoxes.php
+++ b/src/Siklid/Application/Box/ListBoxes.php
@@ -29,21 +29,12 @@ final class ListBoxes extends AbstractAction
 
     public function execute(): PageInterface
     {
+        $after = $this->getAfterCursor();
+        $hashtag = $this->getHashtag();
+        $limit = $this->getLimit();
+
         $boxRepository = $this->dm->getRepository(Box::class);
         assert($boxRepository instanceof BoxRepository);
-
-        $after = (string)$this->request->get('after');
-
-        $hashtag = $this->request->get('hashtag');
-        if (null !== $hashtag) {
-            $hashtag = empty($hashtag) ? null : (string)$hashtag;
-        }
-
-        $limit = (int)$this->getConfig('pagination.limit', 25);
-        if ($this->request->has('size')) {
-            $limit = (int)$this->request->get('size');
-            $this->validateSize($limit);
-        }
 
         return $boxRepository->PaginateAfter($after, $hashtag, $limit);
     }
@@ -58,5 +49,32 @@ final class ListBoxes extends AbstractAction
         if ($limit > $maxSize) {
             throw new ValidationException("Size must be less than or equal to $maxSize.");
         }
+    }
+
+    public function getAfterCursor(): string
+    {
+        return (string)$this->request->get('after');
+    }
+
+    public function getHashtag(): ?string
+    {
+        $hashtag = $this->request->get('hashtag');
+        if (null !== $hashtag) {
+            $hashtag = empty($hashtag) ? null : (string)$hashtag;
+        }
+
+        return $hashtag;
+    }
+
+    public function getLimit(): int
+    {
+        $limit = (int)$this->getConfig('pagination.limit', 25);
+
+        if ($this->request->has('size')) {
+            $limit = (int)$this->request->get('size');
+            $this->validateSize($limit);
+        }
+
+        return $limit;
     }
 }

--- a/src/Siklid/Application/Box/ListBoxes.php
+++ b/src/Siklid/Application/Box/ListBoxes.php
@@ -37,6 +37,9 @@ final class ListBoxes extends AbstractAction
             $hashtag = (string)$hashtag;
         }
         $limit = (int)$this->getConfig('pagination.limit', 25);
+        if ($this->request->has('size')) {
+            $limit = (int)$this->request->get('size');
+        }
 
         return $boxRepository->PaginateAfter($after, $hashtag, $limit);
     }

--- a/src/Siklid/Application/Box/ListBoxes.php
+++ b/src/Siklid/Application/Box/ListBoxes.php
@@ -33,10 +33,12 @@ final class ListBoxes extends AbstractAction
         assert($boxRepository instanceof BoxRepository);
 
         $after = (string)$this->request->get('after');
+
         $hashtag = $this->request->get('hashtag');
         if (null !== $hashtag) {
             $hashtag = empty($hashtag) ? null : (string)$hashtag;
         }
+
         $limit = (int)$this->getConfig('pagination.limit', 25);
         if ($this->request->has('size')) {
             $limit = (int)$this->request->get('size');

--- a/src/Siklid/Document/Box.php
+++ b/src/Siklid/Document/Box.php
@@ -8,6 +8,7 @@ use App\Foundation\Exception\LogicException;
 use App\Siklid\Application\Contract\Entity\BoxInterface;
 use App\Siklid\Application\Contract\Entity\UserInterface;
 use App\Siklid\Application\Contract\Type\RepetitionAlgorithm;
+use App\Siklid\Repository\BoxRepository;
 use DateTimeImmutable;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -21,25 +22,25 @@ use Symfony\Component\Validator\Constraints as Assert;
  * @psalm-suppress MissingConstructor
  * @psalm-suppress PropertyNotSetInConstructor
  */
-#[MongoDB\Document(collection: 'boxes')]
+#[MongoDB\Document(collection: 'boxes', repositoryClass: BoxRepository::class)]
 #[MongoDB\HasLifecycleCallbacks]
 class Box implements BoxInterface
 {
     #[MongoDB\Id]
-    #[Groups(['box:read', 'box:delete', 'box:create'])]
+    #[Groups(['box:read', 'box:delete', 'box:create', 'box:index'])]
     private string $id;
 
     #[MongoDB\Field(type: 'string')]
     #[Assert\NotBlank]
-    #[Groups(['box:read', 'box:create'])]
+    #[Groups(['box:read', 'box:create', 'box:index'])]
     private string $name;
 
     #[MongoDB\Field(type: 'specific')]
-    #[Groups(['box:read', 'box:create'])]
+    #[Groups(['box:read', 'box:create', 'box:index'])]
     private RepetitionAlgorithm $repetitionAlgorithm = RepetitionAlgorithm::Leitner;
 
     #[MongoDB\Field(type: 'string', nullable: true)]
-    #[Groups(['box:read', 'box:create'])]
+    #[Groups(['box:read', 'box:create', 'box:index'])]
     private ?string $description = null;
 
     #[MongoDB\ReferenceMany(targetDocument: Flashcard::class)]
@@ -47,15 +48,15 @@ class Box implements BoxInterface
     private Collection $flashcards;
 
     #[MongoDB\Field(type: 'collection')]
-    #[Groups(['box:read', 'box:create'])]
+    #[Groups(['box:read', 'box:create', 'box:index'])]
     private array $hashtags = [];
 
     #[MongoDB\ReferenceOne(targetDocument: User::class)]
-    #[Groups(['box:read'])]
+    #[Groups(['box:read', 'box:index'])]
     private UserInterface $user;
 
     #[MongoDB\Field(type: 'date_immutable')]
-    #[Groups(['box:read', 'box:create'])]
+    #[Groups(['box:read', 'box:create', 'box:index'])]
     private DateTimeImmutable $createdAt;
 
     #[MongoDB\Field(type: 'date_immutable')]

--- a/src/Siklid/Document/User.php
+++ b/src/Siklid/Document/User.php
@@ -26,7 +26,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 class User implements SiklidUserInterface, Authenticable, UserInterface, HasAccessToken
 {
     #[MongoDB\Id]
-    #[Groups(['user:read'])]
+    #[Groups(['user:read', 'resource:read'])]
     private string $id;
 
     #[MongoDB\Field(type: 'email')]
@@ -42,7 +42,7 @@ class User implements SiklidUserInterface, Authenticable, UserInterface, HasAcce
 
     #[MongoDB\Field(type: 'username')]
     #[Assert\NotBlank]
-    #[Groups(['user:read'])]
+    #[Groups(['user:read', 'resource:read'])]
     #[AppAssert\Username]
     private Username $username;
 

--- a/src/Siklid/Repository/BoxRepository.php
+++ b/src/Siklid/Repository/BoxRepository.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Siklid\Repository;
+
+use App\Foundation\Pagination\Contract\PageInterface;
+use App\Foundation\Pagination\CursorPaginator;
+use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
+
+class BoxRepository extends DocumentRepository
+{
+    public function PaginateAfter(string $after = '', int $perPage = 25): PageInterface
+    {
+        $qb = $this->createQueryBuilder();
+        $qb->sort('id', 'DESC')
+            ->field('user')->prime();
+
+        return CursorPaginator::create()->paginate($qb, $after, $perPage);
+    }
+}

--- a/src/Siklid/Repository/BoxRepository.php
+++ b/src/Siklid/Repository/BoxRepository.php
@@ -17,7 +17,7 @@ class BoxRepository extends DocumentRepository
             ->field('user')->prime();
 
         if (null !== $hashtag) {
-            $qb->field('hashtags')->equals('#'.$hashtag);
+            $qb->field('hashtags')->equals($hashtag);
         }
 
         return CursorPaginator::create()->paginate($qb, $after, $perPage);

--- a/src/Siklid/Repository/BoxRepository.php
+++ b/src/Siklid/Repository/BoxRepository.php
@@ -10,11 +10,15 @@ use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
 
 class BoxRepository extends DocumentRepository
 {
-    public function PaginateAfter(string $after = '', int $perPage = 25): PageInterface
+    public function PaginateAfter(string $after = '', ?string $hashtag = null, int $perPage = 25): PageInterface
     {
         $qb = $this->createQueryBuilder();
         $qb->sort('id', 'DESC')
             ->field('user')->prime();
+
+        if (null !== $hashtag) {
+            $qb->field('hashtags')->equals('#'.$hashtag);
+        }
 
         return CursorPaginator::create()->paginate($qb, $after, $perPage);
     }

--- a/tests/Concern/BoxFactoryTrait.php
+++ b/tests/Concern/BoxFactoryTrait.php
@@ -21,6 +21,7 @@ trait BoxFactoryTrait
         $box->setName($attributes['name'] ?? $this->faker()->word());
         $box->setDescription($attributes['description'] ?? $this->faker()->sentence());
         $box->setUser($attributes['user'] ?? new User());
+        $box->setHashtags($attributes['hashtags'] ?? []);
 
         return $box;
     }

--- a/tests/Feature/Box/ListBoxTest.php
+++ b/tests/Feature/Box/ListBoxTest.php
@@ -112,4 +112,28 @@ class ListBoxTest extends FeatureTestCase
         $this->deleteDocument($user);
         $this->deleteAllDocuments(Box::class);
     }
+
+    /**
+     * @test
+     */
+    public function pagination_size_can_be_specified_with_a_query_param(): void
+    {
+        $client = $this->createCrawler();
+        $user = $this->makeUser();
+        $this->persistDocument($user);
+        for ($i = 0; $i < 5; ++$i) {
+            $box = $this->makeBox(['user' => $user]);
+            $this->persistDocument($box);
+        }
+
+        $client->request('GET', '/api/v1/boxes?size=3');
+
+        $this->assertResponseIsOk();
+        $data = $this->getFromResponse($client, 'data');
+        $this->assertIsArray($data);
+        $this->assertCount(3, $data);
+
+        $this->deleteDocument($user);
+        $this->deleteAllDocuments(Box::class);
+    }
 }

--- a/tests/Feature/Box/ListBoxTest.php
+++ b/tests/Feature/Box/ListBoxTest.php
@@ -136,4 +136,52 @@ class ListBoxTest extends FeatureTestCase
         $this->deleteDocument($user);
         $this->deleteAllDocuments(Box::class);
     }
+
+    /**
+     * @test
+     */
+    public function pagination_size_min_size_is_one(): void
+    {
+        $client = $this->createCrawler();
+        $user = $this->makeUser();
+        $this->persistDocument($user);
+        for ($i = 0; $i < 5; ++$i) {
+            $box = $this->makeBox(['user' => $user]);
+            $this->persistDocument($box);
+        }
+
+        $client->request('GET', '/api/v1/boxes?size=0');
+
+        $this->assertResponseHasValidationError();
+        $this->assertResponseIsJson();
+        $content = (string)$client->getResponse()->getContent();
+        $this->assertStringContainsString('Size must be 1 or greater.', $content);
+
+        $this->deleteDocument($user);
+        $this->deleteAllDocuments(Box::class);
+    }
+
+    /**
+     * @test
+     */
+    public function max_pagination_size_is_100(): void
+    {
+        $client = $this->createCrawler();
+        $user = $this->makeUser();
+        $this->persistDocument($user);
+        for ($i = 0; $i < 5; ++$i) {
+            $box = $this->makeBox(['user' => $user]);
+            $this->persistDocument($box);
+        }
+
+        $client->request('GET', '/api/v1/boxes?size=101');
+
+        $this->assertResponseHasValidationError();
+        $this->assertResponseIsJson();
+        $content = (string)$client->getResponse()->getContent();
+        $this->assertStringContainsString('Size must be less than or equal to 100.', $content);
+
+        $this->deleteDocument($user);
+        $this->deleteAllDocuments(Box::class);
+    }
 }

--- a/tests/Feature/Box/ListBoxTest.php
+++ b/tests/Feature/Box/ListBoxTest.php
@@ -116,6 +116,28 @@ class ListBoxTest extends FeatureTestCase
     /**
      * @test
      */
+    public function empty_hashtag_filter_returns_all_boxes(): void
+    {
+        $client = $this->createCrawler();
+        $user = $this->makeUser();
+        $this->persistDocument($user);
+        $this->persistDocument($this->makeBox(['user' => $user, 'hashtags' => ['#foo', '#not_bar']]));
+        $this->persistDocument($this->makeBox(['user' => $user, 'hashtags' => ['#bar']]));
+
+        $client->request('GET', '/api/v1/boxes?hashtag=');
+
+        $this->assertResponseIsOk();
+        $data = $this->getFromResponse($client, 'data');
+        $this->assertIsArray($data);
+        $this->assertCount(2, $data);
+
+        $this->deleteDocument($user);
+        $this->deleteAllDocuments(Box::class);
+    }
+
+    /**
+     * @test
+     */
     public function pagination_size_can_be_specified_with_a_query_param(): void
     {
         $client = $this->createCrawler();

--- a/tests/Feature/Box/ListBoxTest.php
+++ b/tests/Feature/Box/ListBoxTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Feature\Box;
+
+use App\Siklid\Document\Box;
+use App\Tests\Concern\BoxFactoryTrait;
+use App\Tests\FeatureTestCase;
+
+/**
+ * @psalm-suppress MissingConstructor
+ */
+class ListBoxTest extends FeatureTestCase
+{
+    use BoxFactoryTrait;
+
+    /**
+     * @test
+     */
+    public function guest_can_paginate_all_boxes(): void
+    {
+        $client = $this->createCrawler();
+        $user = $this->makeUser();
+        $this->persistDocument($user);
+        for ($i = 0; $i < 26; ++$i) {
+            $box = $this->makeBox(['user' => $user]);
+            $this->persistDocument($box);
+        }
+
+        $client->request('GET', '/api/v1/boxes');
+
+        $this->assertResponseIsOk();
+        $this->assertResponseIsJson();
+        $this->assertResponseJsonStructure($client, [
+            'data' => [
+                [
+                    'id',
+                    'name',
+                    'repetitionAlgorithm',
+                    'description',
+                    'hashtags',
+                    'user' => [
+                        'id',
+                        'username',
+                    ],
+                ],
+            ],
+            'links' => ['self', 'next'],
+            'meta' => ['count'],
+        ]);
+        $data = $this->getFromResponse($client, 'data');
+        $this->assertIsArray($data);
+        $this->assertCount(25, $data);
+
+        $this->deleteDocument($user);
+        $this->deleteAllDocuments(Box::class);
+    }
+}

--- a/tests/Integration/Siklid/Repository/BoxRepositoryTest.php
+++ b/tests/Integration/Siklid/Repository/BoxRepositoryTest.php
@@ -51,7 +51,7 @@ class BoxRepositoryTest extends IntegrationTestCase
      *
      * @psalm-suppress MixedMethodCall
      */
-    public function paginate_after_filters_by_hash_tag(): void
+    public function paginate_after_filters_by_hashtag(): void
     {
         $user = $this->makeUser();
         $box1 = $this->makeBox(['user' => $user, 'hashtags' => ['#foo']]);
@@ -65,7 +65,7 @@ class BoxRepositoryTest extends IntegrationTestCase
         /** @var BoxRepository $sut */
         $sut = $this->getRepository(Box::class);
 
-        $page = $sut->paginateAfter('', 'foo', 1);
+        $page = $sut->paginateAfter('', '#foo', 1);
 
         $this->assertCount(1, $page->getData());
         $this->assertSame($box3->getId(), $page->getData()[0]->getId());

--- a/tests/Integration/Siklid/Repository/BoxRepositoryTest.php
+++ b/tests/Integration/Siklid/Repository/BoxRepositoryTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Siklid\Repository;
+
+use App\Siklid\Document\Box;
+use App\Siklid\Repository\BoxRepository;
+use App\Tests\Concern\BoxFactoryTrait;
+use App\Tests\Concern\UserFactoryTrait;
+use App\Tests\IntegrationTestCase;
+
+/**
+ * @psalm-suppress MissingConstructor
+ */
+class BoxRepositoryTest extends IntegrationTestCase
+{
+    use UserFactoryTrait;
+    use BoxFactoryTrait;
+
+    /**
+     * @test
+     *
+     * @psalm-suppress MixedMethodCall
+     */
+    public function paginate_after_uses_the_after_cursor(): void
+    {
+        $user = $this->makeUser();
+        $box1 = $this->makeBox(['user' => $user]);
+        $box2 = $this->makeBox(['user' => $user]);
+        $box3 = $this->makeBox(['user' => $user]);
+        $this->persistDocument($user);
+        $this->persistDocument($box1);
+        $this->persistDocument($box2);
+        $this->persistDocument($box3);
+
+        /** @var BoxRepository $sut */
+        $sut = $this->getRepository(Box::class);
+
+        $page = $sut->paginateAfter($box2->getId(), null, 1);
+
+        $this->assertCount(1, $page->getData());
+        $this->assertSame($box1->getId(), $page->getData()[0]->getId());
+
+        $this->deleteDocument($user);
+        $this->deleteAllDocuments(Box::class);
+    }
+
+    /**
+     * @test
+     *
+     * @psalm-suppress MixedMethodCall
+     */
+    public function paginate_after_filters_by_hash_tag(): void
+    {
+        $user = $this->makeUser();
+        $box1 = $this->makeBox(['user' => $user, 'hashtags' => ['#foo']]);
+        $box2 = $this->makeBox(['user' => $user, 'hashtags' => ['#bar']]);
+        $box3 = $this->makeBox(['user' => $user, 'hashtags' => ['#foo']]);
+        $this->persistDocument($user);
+        $this->persistDocument($box1);
+        $this->persistDocument($box2);
+        $this->persistDocument($box3);
+
+        /** @var BoxRepository $sut */
+        $sut = $this->getRepository(Box::class);
+
+        $page = $sut->paginateAfter('', 'foo', 1);
+
+        $this->assertCount(1, $page->getData());
+        $this->assertSame($box3->getId(), $page->getData()[0]->getId());
+
+        $this->deleteDocument($user);
+        $this->deleteAllDocuments(Box::class);
+    }
+
+    /**
+     * @test
+     *
+     * @psalm-suppress MixedMethodCall
+     */
+    public function paginate_after_limit(): void
+    {
+        $user = $this->makeUser();
+        $box1 = $this->makeBox(['user' => $user]);
+        $box2 = $this->makeBox(['user' => $user]);
+        $box3 = $this->makeBox(['user' => $user]);
+        $this->persistDocument($user);
+        $this->persistDocument($box1);
+        $this->persistDocument($box2);
+        $this->persistDocument($box3);
+
+        /** @var BoxRepository $sut */
+        $sut = $this->getRepository(Box::class);
+
+        $page = $sut->paginateAfter('', null, 1);
+
+        $this->assertCount(1, $page->getData());
+        $this->assertSame($box3->getId(), $page->getData()[0]->getId());
+
+        $this->deleteDocument($user);
+        $this->deleteAllDocuments(Box::class);
+    }
+}

--- a/tests/Unit/Foundation/Http/RequestTest.php
+++ b/tests/Unit/Foundation/Http/RequestTest.php
@@ -151,4 +151,43 @@ class RequestTest extends TestCase
 
         $this->assertSame('bar', $actual);
     }
+
+    /**
+     * @test
+     */
+    public function has_checks_existence_on_query(): void
+    {
+        $sut = new Sut($this->requestStack, $this->util);
+        $this->requestStack->push(new Request(['foo' => 'bar']));
+
+        $actual = $sut->has('foo');
+
+        $this->assertTrue($actual);
+    }
+
+    /**
+     * @test
+     */
+    public function has_checks_existence_on_post_params(): void
+    {
+        $sut = new Sut($this->requestStack, $this->util);
+        $this->requestStack->push(new Request([], ['foo' => 'bar']));
+
+        $actual = $sut->has('foo');
+
+        $this->assertTrue($actual);
+    }
+
+    /**
+     * @test
+     */
+    public function has(): void
+    {
+        $sut = new Sut($this->requestStack, $this->util);
+        $this->requestStack->push(new Request());
+
+        $actual = $sut->has('foo');
+
+        $this->assertFalse($actual);
+    }
 }


### PR DESCRIPTION
| Q             | A                                                                  |
|---------------|--------------------------------------------------------------------|
| Branch?       | 1.x <!-- see below -->                                             |
| Bug fix?      | no                                                             |
| New feature?  | yes <!-- please update /CHANGELOG.md files -->                  |
| Deprecations? | no <!-- please update UPGRADE-*.md and /CHANGELOG.md files --> |
| Tickets       | Fix #98  <!-- prefix each issue number with "Fix #", -->           |
| License       | MIT                                                                |


I replaced the ordering by `CreatedAt` with `id`. The Mongo ID is orderable, so it should be fine. This way we avoid adding an extra index for the `createdAt` field.

Maximum pagination size is configured in the `sikilid.yaml` it is set to 100 by default.

The tag filter is in the form of `tag1,tag2,tag3`. Adding `#` to the beginning of the tag will break the query parameters. 

**TODO**
- [x] A user can list all the boxes
    - [x]  The boxes are ordered by ~creation date~ id. The Id field still does the job.
    - [x] Results are paginated (e.g. 10 boxes per page) [Actual value is 25/page]
    - [x] The pagination page can be specified with a query parameter (max 50 boxes per page & min 1 box per page)
- [x]  A user can list a subset of boxes based on a tag filter
    - [x]  The boxes are ordered by creation date
    - [x]  The tag filter is optional
    - [x]  The tag filter is a string in the form of a hashtag ~(e.g. #tag, #another_tag)~ adding `#` does not work as a query string.
    - [x]  Empty filter returns all the boxes