### PR TITLE
[1.x] Add custom validator

### DIFF
--- a/src/Foundation/Action/AbstractAction.php
+++ b/src/Foundation/Action/AbstractAction.php
@@ -60,4 +60,31 @@ abstract class AbstractAction extends AbstractController implements ActionInterf
 
         return $config ?? $default;
     }
+
+    /**
+     * Creates a new form instance from the given type.
+     *
+     * @template       T
+     *
+     * @param class-string<T>      $class
+     * @param array<string, mixed> $data
+     *
+     * @psalm-suppress MixedMethodCall - The user should know about the class type
+     * @psalm-suppress MixedAssignment - Expected to be mixed
+     *
+     * @return T
+     */
+    public function fill(string $class, array $data): object
+    {
+        $object = new $class();
+
+        foreach ($data as $key => $value) {
+            $setter = 'set'.ucfirst($key);
+            if (method_exists($object, $setter)) {
+                $object->$setter($value);
+            }
+        }
+
+        return $object;
+    }
 }

--- a/src/Foundation/Exception/ValidationException.php
+++ b/src/Foundation/Exception/ValidationException.php
@@ -62,6 +62,14 @@ class ValidationException extends SiklidException implements RenderableInterface
     {
         $errors = [];
 
+        if (null !== $this->violationList) {
+            foreach ($this->violationList as $violation) {
+                $errors[$violation->getPropertyPath()][] = $violation->getMessage();
+            }
+
+            return $errors;
+        }
+
         if (null === $this->errorIterator) {
             return $errors;
         }

--- a/src/Foundation/Exception/ValidationException.php
+++ b/src/Foundation/Exception/ValidationException.php
@@ -8,6 +8,7 @@ use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormErrorIterator;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Throwable;
 
 /**
@@ -17,6 +18,8 @@ use Throwable;
 class ValidationException extends SiklidException implements RenderableInterface
 {
     protected ?FormErrorIterator $errorIterator = null;
+
+    protected ?ConstraintViolationListInterface $violationList = null;
 
     public function __construct(string $message = 'Invalid request', int $code = 0, Throwable $previous = null)
     {
@@ -29,6 +32,13 @@ class ValidationException extends SiklidException implements RenderableInterface
     public function setErrorIterator(FormErrorIterator $errorIterator): void
     {
         $this->errorIterator = $errorIterator;
+    }
+
+    public function setViolationList(?ConstraintViolationListInterface $violationList = null): ValidationException
+    {
+        $this->violationList = $violationList;
+
+        return $this;
     }
 
     /**

--- a/src/Foundation/Validation/Validator.php
+++ b/src/Foundation/Validation/Validator.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Foundation\Validation;
+
+use App\Foundation\Exception\ValidationException;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\GroupSequence;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * This validator is a wrapper around the Symfony validator.
+ * It will throw a ValidationException when validation fails.
+ */
+class Validator
+{
+    private ValidatorInterface $validator;
+
+    public function __construct(ValidatorInterface $validator)
+    {
+        $this->validator = $validator;
+    }
+
+    /**
+     * Validates a value against a constraint or a list of constraints.
+     *
+     * @param Constraint|Constraint[] $constraints                               The constraint(s) to validate against
+     * @param string|GroupSequence|array<string|GroupSequence>|null $groups      The validation groups to validate. If
+     *                                                                           none is given, "Default" is assumed
+     */
+    public function validate(
+        mixed $value,
+        Constraint|array $constraints = null,
+        string|GroupSequence|array $groups =
+        null
+    ): ConstraintViolationListInterface {
+        $violations = $this->validator->validate(
+            $value,
+            $constraints,
+            $groups
+        );
+
+        $validationException = new ValidationException();
+        $validationException->setViolationList($violations);
+
+        if ($violations->count() > 0) {
+            throw $validationException;
+        }
+
+        return $violations;
+    }
+}

--- a/src/Foundation/Validation/Validator.php
+++ b/src/Foundation/Validation/Validator.php
@@ -53,10 +53,9 @@ final class Validator
             $groups
         );
 
-        $validationException = new ValidationException();
-        $validationException->setViolationList($violations);
-
         if ($violations->count() > 0) {
+            $validationException = new ValidationException();
+            $validationException->setViolationList($violations);
             throw $validationException;
         }
 

--- a/src/Foundation/Validation/Validator.php
+++ b/src/Foundation/Validation/Validator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Foundation\Validation;
 
 use App\Foundation\Exception\ValidationException;
+use App\Foundation\Validation\ValidatorInterface as AppValidator;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\GroupSequence;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
@@ -18,7 +19,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  * This validator is a wrapper around the Symfony validator.
  * It will throw a ValidationException when validation fails.
  */
-final class Validator
+final class Validator implements AppValidator
 {
     private ValidatorInterface $validator;
 

--- a/src/Foundation/Validation/Validator.php
+++ b/src/Foundation/Validation/Validator.php
@@ -8,13 +8,17 @@ use App\Foundation\Exception\ValidationException;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\GroupSequence;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Exception\NoSuchMetadataException;
+use Symfony\Component\Validator\Mapping\MetadataInterface;
+use Symfony\Component\Validator\Validator\ContextualValidatorInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * This validator is a wrapper around the Symfony validator.
  * It will throw a ValidationException when validation fails.
  */
-class Validator
+final class Validator
 {
     private ValidatorInterface $validator;
 
@@ -26,9 +30,16 @@ class Validator
     /**
      * Validates a value against a constraint or a list of constraints.
      *
+     * If no constraint is passed, the constraint
+     * {@link \Symfony\Component\Validator\Constraints\Valid} is assumed.
+     *
      * @param Constraint|Constraint[]                               $constraints The constraint(s) to validate against
      * @param string|GroupSequence|array<string|GroupSequence>|null $groups      The validation groups to validate. If
      *                                                                           none is given, "Default" is assumed
+     *
+     * @return ConstraintViolationListInterface A list of constraint violations
+     *                                          If the list is empty, validation
+     *                                          succeeded
      */
     public function validate(
         mixed $value,
@@ -50,5 +61,100 @@ class Validator
         }
 
         return $violations;
+    }
+
+    /**
+     * Returns the metadata for the given value.
+     *
+     * @throws NoSuchMetadataException If no metadata exists for the given value
+     */
+    public function getMetadataFor(mixed $value): MetadataInterface
+    {
+        return $this->validator->getMetadataFor($value);
+    }
+
+    /**
+     * Returns whether the class is able to return metadata for the given value.
+     */
+    public function hasMetadataFor(mixed $value): bool
+    {
+        return $this->validator->hasMetadataFor($value);
+    }
+
+    /**
+     * Validates a property of an object against the constraints specified
+     * for this property.
+     *
+     * @param string                                                $propertyName The name of the validated property
+     * @param string|GroupSequence|array<string|GroupSequence>|null $groups       The validation groups to validate. If
+     *                                                                            none is given, "Default" is assumed
+     *
+     * @return ConstraintViolationListInterface A list of constraint violations
+     *                                          If the list is empty, validation
+     *                                          succeeded
+     */
+    public function validateProperty(
+        object $object,
+        string $propertyName,
+        array|GroupSequence|string $groups = null
+    ): ConstraintViolationListInterface {
+        return $this->validator->validateProperty(
+            $object,
+            $propertyName,
+            $groups
+        );
+    }
+
+    /**
+     * Validates a value against the constraints specified for an object's
+     * property.
+     *
+     * @param object|string                                         $objectOrClass The object or its class name
+     * @param string                                                $propertyName  The name of the property
+     * @param mixed                                                 $value         The value to validate against the
+     *                                                                             property's constraints
+     * @param string|GroupSequence|array<string|GroupSequence>|null $groups        The validation groups to validate.
+     *                                                                             If none is given, "Default" is
+     *                                                                             assumed
+     *
+     * @return ConstraintViolationListInterface A list of constraint violations
+     *                                          If the list is empty, validation
+     *                                          succeeded
+     */
+    public function validatePropertyValue(
+        object|string $objectOrClass,
+        string $propertyName,
+        mixed $value,
+        array|GroupSequence|string $groups = null
+    ): ConstraintViolationListInterface {
+        return $this->validator->validatePropertyValue(
+            $objectOrClass,
+            $propertyName,
+            $value,
+            $groups
+        );
+    }
+
+    /**
+     * Starts a new validation context and returns a validator for that context.
+     *
+     * The returned validator collects all violations generated within its
+     * context. You can access these violations with the
+     * {@link ContextualValidatorInterface::getViolations()} method.
+     */
+    public function startContext(): ContextualValidatorInterface
+    {
+        return $this->validator->startContext();
+    }
+
+    /**
+     * Returns a validator in the given execution context.
+     *
+     * The returned validator adds all generated violations to the given
+     * context.
+     */
+    public function inContext(ExecutionContextInterface $context): ContextualValidatorInterface
+    {
+        return $this->validator->inContext($context);
     }
 }

--- a/src/Foundation/Validation/Validator.php
+++ b/src/Foundation/Validation/Validator.php
@@ -26,7 +26,7 @@ class Validator
     /**
      * Validates a value against a constraint or a list of constraints.
      *
-     * @param Constraint|Constraint[] $constraints                               The constraint(s) to validate against
+     * @param Constraint|Constraint[]                               $constraints The constraint(s) to validate against
      * @param string|GroupSequence|array<string|GroupSequence>|null $groups      The validation groups to validate. If
      *                                                                           none is given, "Default" is assumed
      */

--- a/src/Foundation/Validation/ValidatorInterface.php
+++ b/src/Foundation/Validation/ValidatorInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Foundation\Validation;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\GroupSequence;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+
+/**
+ * Validates a value against a constraint or a list of constraints.
+ */
+interface ValidatorInterface
+{
+    /**
+     * Validates a value against a constraint or a list of constraints.
+     *
+     * If no constraint is passed, the constraint
+     * {@link \Symfony\Component\Validator\Constraints\Valid} is assumed.
+     *
+     * @param Constraint|Constraint[]                               $constraints The constraint(s) to validate against
+     * @param string|GroupSequence|array<string|GroupSequence>|null $groups      The validation groups to validate. If
+     *                                                                           none is given, "Default" is assumed
+     *
+     * @return ConstraintViolationListInterface A list of constraint violations
+     *                                          If the list is empty, validation
+     *                                          succeeded
+     */
+    public function validate(
+        mixed $value,
+        Constraint|array $constraints = null,
+        string|GroupSequence|array $groups =
+        null
+    ): ConstraintViolationListInterface;
+}

--- a/tests/Foundation/Action/AbstractActionTest.php
+++ b/tests/Foundation/Action/AbstractActionTest.php
@@ -96,4 +96,57 @@ class AbstractActionTest extends TestCase
     {
         $this->assertSame('default', $sut->getConfig('foo.missing', 'default'));
     }
+
+    /**
+     * @test
+     */
+    public function fill(): void
+    {
+        $sut = $this->getMockForAbstractClass(AbstractAction::class);
+        $data = [
+            'foo' => 'bar',
+            'bar' => 'baz',
+            'noSetterProperty' => 'foo',
+        ];
+
+        $result = $sut->fill(FillableClass::class, $data);
+
+        $this->assertInstanceOf(FillableClass::class, $result);
+        $this->assertSame('bar', $result->getFoo());
+        $this->assertSame('baz', $result->getBar());
+    }
+}
+
+/**
+ * @psalm-suppress MissingConstructor
+ */
+class FillableClass
+{
+    private string $foo;
+
+    private string $bar;
+
+    public function getFoo(): string
+    {
+        return $this->foo;
+    }
+
+    public function setFoo(string $foo): FillableClass
+    {
+        $this->foo = $foo;
+
+        return $this;
+    }
+
+    public function getBar(): string
+    {
+        return $this->bar;
+    }
+
+    public function setBar(string $bar): FillableClass
+    {
+        $this->bar = $bar;
+
+        return $this;
+    }
 }

--- a/tests/Foundation/Action/AbstractActionTest.php
+++ b/tests/Foundation/Action/AbstractActionTest.php
@@ -7,7 +7,7 @@ namespace App\Tests\Foundation\Action;
 use App\Foundation\Action\AbstractAction;
 use App\Foundation\Action\ValidatableInterface;
 use App\Foundation\Exception\ValidationException;
-use App\Tests\TestCase;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\Form\FormInterface;
@@ -15,7 +15,7 @@ use Symfony\Component\Form\FormInterface;
 /**
  * @psalm-suppress MissingConstructor
  */
-class AbstractionActionTest extends TestCase
+class AbstractActionTest extends TestCase
 {
     private ValidatableInterface $request;
 

--- a/tests/Foundation/Action/AbstractActionTest.php
+++ b/tests/Foundation/Action/AbstractActionTest.php
@@ -7,7 +7,7 @@ namespace App\Tests\Foundation\Action;
 use App\Foundation\Action\AbstractAction;
 use App\Foundation\Action\ValidatableInterface;
 use App\Foundation\Exception\ValidationException;
-use PHPUnit\Framework\TestCase;
+use App\Tests\TestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\Form\FormInterface;

--- a/tests/Foundation/Exception/ValidationExceptionTest.php
+++ b/tests/Foundation/Exception/ValidationExceptionTest.php
@@ -10,6 +10,7 @@ use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormErrorIterator;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
 
 class ValidationExceptionTest extends TestCase
 {
@@ -34,6 +35,30 @@ class ValidationExceptionTest extends TestCase
             [$formError]
         );
         $sut->setErrorIterator($errorIterator);
+
+        $response = $sut->render();
+
+        $this->assertSame(422, $response->getStatusCode());
+        $expectedContent = '{"message":"Invalid request","errors":{"property_path":["Error message"]}}';
+        $this->assertSame($expectedContent, $response->getContent());
+    }
+
+    /**
+     * @test
+     */
+    public function render_with_violation_list(): void
+    {
+        $sut = new ValidationException();
+        $violation = new ConstraintViolation(
+            'Error message',
+            'Error message',
+            [],
+            'root',
+            'property_path',
+            'invalid_value'
+        );
+        $violationList = new ConstraintViolationList([$violation]);
+        $sut->setViolationList($violationList);
 
         $response = $sut->render();
 

--- a/tests/Foundation/Validation/ValidatorTest.php
+++ b/tests/Foundation/Validation/ValidatorTest.php
@@ -7,7 +7,7 @@ namespace App\Tests\Foundation\Validation;
 use App\Foundation\Exception\ValidationException;
 use App\Foundation\Validation\Validator;
 use App\Tests\Concern\KernelTestCaseTrait;
-use PHPUnit\Framework\TestCase;
+use App\Tests\TestCase;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 

--- a/tests/Foundation/Validation/ValidatorTest.php
+++ b/tests/Foundation/Validation/ValidatorTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Foundation\Validation;
+
+use App\Foundation\Exception\ValidationException;
+use App\Foundation\Validation\Validator;
+use App\Tests\Concern\KernelTestCaseTrait;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class ValidatorTest extends TestCase
+{
+    use KernelTestCaseTrait;
+
+    /**
+     * @test
+     */
+    public function validate_with_invalid_data(): void
+    {
+        $this->expectException(ValidationException::class);
+
+        $validator = $this->container()->get(ValidatorInterface::class);
+        $sut = new Validator($validator);
+
+        $sut->validate(new Foo());
+    }
+
+    /**
+     * @test
+     */
+    public function validate_with_valid_data(): void
+    {
+        $validator = $this->container()->get(ValidatorInterface::class);
+        $sut = new Validator($validator);
+
+        $violations = $sut->validate(new Foo('foo'));
+        $this->assertCount(0, $violations);
+    }
+}
+
+class Foo
+{
+    #[Assert\NotBlank]
+    public ?string $id = null;
+
+    public function __construct(?string $id = null)
+    {
+        $this->id = $id;
+    }
+}


### PR DESCRIPTION
| Q             | A                                                                  |
|---------------|--------------------------------------------------------------------|
| Branch?       | 1.x <!-- see below -->                                             |
| Bug fix?      | yes/no                                                             |
| New feature?  | yes <!-- please update /CHANGELOG.md files -->                  |
| Deprecations? | no <!-- please update UPGRADE-*.md and /CHANGELOG.md files --> |
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", -->           |
| License       | MIT                                                                |

This PR adds a custom validator that implements all methods of the SF validator interface but it does not implement it.

It's a wrapper around the recursive validator from SF, but it throws a validation exception in case of invalid data.