### PR TITLE
[1.x] Add exists constraint

### DIFF
--- a/src/Foundation/Validation/Constraint/Exists.php
+++ b/src/Foundation/Validation/Constraint/Exists.php
@@ -10,6 +10,10 @@ use Symfony\Component\Validator\Constraint;
 #[Attribute]
 class Exists extends Constraint
 {
+    public string $field = 'id';
+
+    public ?string $document = null;
+
     public function validatedBy(): string
     {
         return ExistsValidator::class;
@@ -17,6 +21,6 @@ class Exists extends Constraint
 
     public function message(): string
     {
-        return 'The value "{{ value }}" does not exist.';
+        return 'The document {{ document }} with {{ field }}: {{ value }} does not exist.';
     }
 }

--- a/src/Foundation/Validation/Constraint/Exists.php
+++ b/src/Foundation/Validation/Constraint/Exists.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Foundation\Validation\Constraint;
+
+use Attribute;
+use Symfony\Component\Validator\Constraint;
+
+#[Attribute]
+class Exists extends Constraint
+{
+    public function validatedBy(): string
+    {
+        return ExistsValidator::class;
+    }
+
+    public function message(): string
+    {
+        return 'The value "{{ value }}" does not exist.';
+    }
+}

--- a/src/Foundation/Validation/Constraint/Exists.php
+++ b/src/Foundation/Validation/Constraint/Exists.php
@@ -30,8 +30,8 @@ class Exists extends Constraint
     ) {
         parent::__construct([], $groups, $payload);
 
-        $this->field = $field;
         $this->document = $document;
+        $this->field = $field;
     }
 
     public function validatedBy(): string

--- a/src/Foundation/Validation/Constraint/Exists.php
+++ b/src/Foundation/Validation/Constraint/Exists.php
@@ -5,14 +5,34 @@ declare(strict_types=1);
 namespace App\Foundation\Validation\Constraint;
 
 use Attribute;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
+/**
+ * @psalm-suppress PropertyNotSetInConstructor
+ */
 #[Attribute]
 class Exists extends Constraint
 {
-    public string $field = 'id';
+    public string $field;
 
-    public ?string $document = null;
+    public ?string $document;
+
+    /**
+     * @psalm-suppress MixedArgumentTypeCoercion
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        string $field = 'id',
+        ?string $document = null,
+        array $groups = null,
+        mixed $payload = null
+    ) {
+        parent::__construct([], $groups, $payload);
+
+        $this->field = $field;
+        $this->document = $document;
+    }
 
     public function validatedBy(): string
     {

--- a/src/Foundation/Validation/Constraint/Exists.php
+++ b/src/Foundation/Validation/Constraint/Exists.php
@@ -23,8 +23,8 @@ class Exists extends Constraint
      */
     #[HasNamedArguments]
     public function __construct(
-        string $field = 'id',
         ?string $document = null,
+        string $field = 'id',
         array $groups = null,
         mixed $payload = null
     ) {

--- a/src/Foundation/Validation/Constraint/ExistsValidator.php
+++ b/src/Foundation/Validation/Constraint/ExistsValidator.php
@@ -21,6 +21,9 @@ class ExistsValidator extends ConstraintValidator
 
     /**
      * {@inheritDoc}
+     *
+     * @psalm-suppress MixedAssignment - User should know about the types.
+     * @psalm-suppress MixedMethodCall - It's a getter method.
      */
     public function validate(mixed $value, Constraint $constraint): void
     {
@@ -42,6 +45,11 @@ class ExistsValidator extends ConstraintValidator
 
         if (! class_exists($constraint->document)) {
             throw new InvalidArgumentException(sprintf('Document class "%s" does not exist.', $constraint->document));
+        }
+
+        if ($value instanceof $constraint->document) {
+            $getter = 'get'.ucfirst($constraint->field);
+            $value = $value->$getter();
         }
 
         $document = $this->dm->getRepository($constraint->document)->findOneBy([

--- a/src/Foundation/Validation/Constraint/ExistsValidator.php
+++ b/src/Foundation/Validation/Constraint/ExistsValidator.php
@@ -4,6 +4,56 @@ declare(strict_types=1);
 
 namespace App\Foundation\Validation\Constraint;
 
-class ExistsValidator
+use Doctrine\ODM\MongoDB\DocumentManager;
+use InvalidArgumentException;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+class ExistsValidator extends ConstraintValidator
 {
+    private DocumentManager $dm;
+
+    public function __construct(DocumentManager $dm)
+    {
+        $this->dm = $dm;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (empty($value)) {
+            return;
+        }
+
+        if (! $constraint instanceof Exists) {
+            throw new UnexpectedTypeException($constraint, Exists::class);
+        }
+
+        if (empty($constraint->document)) {
+            throw new InvalidArgumentException('Document class must be specified.');
+        }
+
+        if (empty($constraint->field)) {
+            throw new InvalidArgumentException('Field must be specified.');
+        }
+
+        if (! class_exists($constraint->document)) {
+            throw new InvalidArgumentException(sprintf('Document class "%s" does not exist.', $constraint->document));
+        }
+
+        $document = $this->dm->getRepository($constraint->document)->findOneBy([
+            $constraint->field => $value,
+        ]);
+
+        if (null === $document) {
+            $this->context->buildViolation($constraint->message())
+                ->setParameter('{{ document }}', $constraint->document)
+                ->setParameter('{{ field }}', $constraint->field)
+                ->setParameter('{{ value }}', (string)$value)
+                ->addViolation();
+        }
+    }
 }

--- a/src/Foundation/Validation/Constraint/ExistsValidator.php
+++ b/src/Foundation/Validation/Constraint/ExistsValidator.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Foundation\Validation\Constraint;
+
+class ExistsValidator
+{
+}

--- a/src/Siklid/Document/Box.php
+++ b/src/Siklid/Document/Box.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Siklid\Document;
 
 use App\Foundation\Exception\LogicException;
+use App\Foundation\Validation\Constraint as AppAssert;
 use App\Siklid\Application\Contract\Entity\BoxInterface;
 use App\Siklid\Application\Contract\Entity\UserInterface;
 use App\Siklid\Application\Contract\Type\RepetitionAlgorithm;
@@ -54,6 +55,7 @@ class Box implements BoxInterface
     #[MongoDB\ReferenceOne(targetDocument: User::class)]
     #[Groups(['box:read', 'box:index'])]
     #[Assert\NotBlank]
+    #[AppAssert\Exists(document: User::class)]
     private UserInterface $user;
 
     #[MongoDB\Field(type: 'date_immutable')]

--- a/tests/Concern/Assertion/AssertAttributeTrait.php
+++ b/tests/Concern/Assertion/AssertAttributeTrait.php
@@ -22,4 +22,20 @@ trait AssertAttributeTrait
         $attributeNames = array_map(static fn ($attribute) => $attribute->getName(), $classAttributes);
         $this->assertContains($attribute, $attributeNames, $message);
     }
+
+    /**
+     * Asserts a class method has an attribute.
+     */
+    protected function assertMethodHasAttribute(
+        object $sut,
+        string $method,
+        string $attribute,
+        string $message = ''
+    ): void {
+        $reflection = new ReflectionClass($sut);
+        $method = $reflection->getMethod($method);
+        $methodAttributes = $method->getAttributes();
+        $attributeNames = array_map(static fn ($attribute) => $attribute->getName(), $methodAttributes);
+        $this->assertContains($attribute, $attributeNames, $message);
+    }
 }

--- a/tests/Concern/Assertion/AssertAttributeTrait.php
+++ b/tests/Concern/Assertion/AssertAttributeTrait.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Concern\Assertion;
+
+use App\Tests\TestCase;
+use ReflectionClass;
+
+/**
+ * @mixin TestCase
+ */
+trait AssertAttributeTrait
+{
+    /**
+     * Asserts an attribute is present on the given object.
+     */
+    protected function assertHasAttribute(object $sut, string $attribute, string $message = ''): void
+    {
+        $reflection = new ReflectionClass($sut);
+        $classAttributes = $reflection->getAttributes();
+        $attributeNames = array_map(static fn ($attribute) => $attribute->getName(), $classAttributes);
+        $this->assertContains($attribute, $attributeNames, $message);
+    }
+}

--- a/tests/Foundation/Validation/Constraint/ExistsTest.php
+++ b/tests/Foundation/Validation/Constraint/ExistsTest.php
@@ -8,6 +8,7 @@ use App\Foundation\Validation\Constraint\Exists;
 use App\Foundation\Validation\Constraint\ExistsValidator;
 use App\Tests\TestCase;
 use Attribute;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 
 class ExistsTest extends TestCase
 {
@@ -19,6 +20,16 @@ class ExistsTest extends TestCase
         $sut = new Exists();
 
         $this->assertHasAttribute($sut, Attribute::class);
+    }
+
+    /**
+     * @test
+     */
+    public function has_named_arguments(): void
+    {
+        $sut = new Exists();
+
+        $this->assertMethodHasAttribute($sut, '__construct', HasNamedArguments::class);
     }
 
     /**

--- a/tests/Foundation/Validation/Constraint/ExistsTest.php
+++ b/tests/Foundation/Validation/Constraint/ExistsTest.php
@@ -38,6 +38,6 @@ class ExistsTest extends TestCase
     {
         $sut = new Exists();
 
-        $this->assertSame('The value "{{ value }}" does not exist.', $sut->message());
+        $this->assertSame('The document {{ document }} with {{ field }}: {{ value }} does not exist.', $sut->message());
     }
 }

--- a/tests/Foundation/Validation/Constraint/ExistsTest.php
+++ b/tests/Foundation/Validation/Constraint/ExistsTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Foundation\Validation\Constraint;
+
+use App\Foundation\Validation\Constraint\Exists;
+use App\Foundation\Validation\Constraint\ExistsValidator;
+use App\Tests\TestCase;
+use Attribute;
+
+class ExistsTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function is_attribute(): void
+    {
+        $sut = new Exists();
+
+        $this->assertHasAttribute($sut, Attribute::class);
+    }
+
+    /**
+     * @test
+     */
+    public function validated_by(): void
+    {
+        $sut = new Exists();
+
+        $this->assertSame(ExistsValidator::class, $sut->validatedBy());
+    }
+
+    /**
+     * @test
+     */
+    public function message(): void
+    {
+        $sut = new Exists();
+
+        $this->assertSame('The value "{{ value }}" does not exist.', $sut->message());
+    }
+}

--- a/tests/Foundation/Validation/Constraint/ExistsValidatorTest.php
+++ b/tests/Foundation/Validation/Constraint/ExistsValidatorTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Foundation\Validation\Constraint;
+
+use App\Foundation\Validation\Constraint\Exists;
+use App\Foundation\Validation\Constraint\ExistsValidator;
+use App\Siklid\Document\User;
+use App\Tests\Concern\Factory\UserFactoryTrait;
+use App\Tests\Concern\KernelTestCaseTrait;
+use App\Tests\TestCase;
+use InvalidArgumentException;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Context\ExecutionContext;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class ExistsValidatorTest extends TestCase
+{
+    use KernelTestCaseTrait;
+    use UserFactoryTrait;
+
+    /**
+     * @test
+     */
+    public function it_validates_exists_constraint(): void
+    {
+        $constraint = new class() extends Constraint {
+        };
+        $sut = new ExistsValidator($this->getDocumentManager());
+
+        $this->expectException(UnexpectedTypeException::class);
+
+        $sut->validate('foo', $constraint);
+    }
+
+    /**
+     * @test
+     */
+    public function it_skips_empty_values(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $sut = new ExistsValidator($this->getDocumentManager());
+
+        $sut->validate(null, new Exists());
+        $sut->validate('', new Exists());
+    }
+
+    /**
+     * @test
+     */
+    public function it_requires_document(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectErrorMessage('Document class must be specified.');
+
+        $sut = new ExistsValidator($this->getDocumentManager());
+
+        $sut->validate('foo', new Exists());
+    }
+
+    /**
+     * @test
+     */
+    public function it_requires_field(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectErrorMessage('Field must be specified.');
+
+        $sut = new ExistsValidator($this->getDocumentManager());
+
+        $sut->validate('foo', new Exists(['document' => 'foo', 'field' => '']));
+    }
+
+    /**
+     * @test
+     */
+    public function document_class_should_exist(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectErrorMessage('Document class "foo" does not exist.');
+
+        $sut = new ExistsValidator($this->getDocumentManager());
+
+        $sut->validate('foo', new Exists(['document' => 'foo', 'field' => 'bar']));
+    }
+
+    /**
+     * @test
+     *
+     * @psalm-suppress InternalClass
+     * @psalm-suppress InternalMethod
+     */
+    public function it_adds_violation_if_not_exists(): void
+    {
+        $sut = new ExistsValidator($this->getDocumentManager());
+        $context = new ExecutionContext(
+            $this->createMock(ValidatorInterface::class),
+            'root',
+            $this->createMock(TranslatorInterface::class)
+        );
+        $sut->initialize($context);
+
+        $sut->validate('bar', new Exists(['document' => User::class, 'field' => 'foo']));
+
+        $this->assertCount(1, $context->getViolations());
+    }
+
+    /**
+     * @test
+     *
+     * @psalm-suppress InternalClass
+     * @psalm-suppress InternalMethod
+     */
+    public function it_passes_if_data_exists(): void
+    {
+        $user = $this->makeUser();
+        $this->persistDocument($user);
+        $sut = new ExistsValidator($this->getDocumentManager());
+        $context = new ExecutionContext(
+            $this->createMock(ValidatorInterface::class),
+            'root',
+            $this->createMock(TranslatorInterface::class)
+        );
+        $sut->initialize($context);
+
+        $sut->validate($user->getId(), new Exists(['document' => User::class]));
+        $sut->validate($user->getId(), new Exists(['document' => User::class, 'field' => 'id']));
+        $sut->validate($user->getUsername(), new Exists(['document' => User::class, 'field' => 'username']));
+
+        $this->assertCount(0, $context->getViolations());
+    }
+}

--- a/tests/Foundation/Validation/Constraint/SlugValidatorTest.php
+++ b/tests/Foundation/Validation/Constraint/SlugValidatorTest.php
@@ -35,7 +35,7 @@ class SlugValidatorTest extends TestCase
     {
         parent::setUp();
 
-        $this->sut = new \App\Foundation\Validation\Constraint\SlugValidator();
+        $this->sut = new SlugValidator();
         $this->context = new ExecutionContext(
             $this->createMock(ValidatorInterface::class),
             'slug',

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests;
 
+use App\Tests\Concern\Assertion\AssertAttributeTrait;
 use Doctrine\ODM\MongoDB\Types\Type;
 use ReflectionClass;
 use ReflectionException;
@@ -16,6 +17,8 @@ use ReflectionMethod;
  */
 abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
+    use AssertAttributeTrait;
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
| Q             | A                                                                  |
|---------------|--------------------------------------------------------------------|
| Branch?       | 1.x <!-- see below -->                                             |
| Bug fix?      | no                                                           |
| New feature?  | no <!-- please update /CHANGELOG.md files -->                  |
| Deprecations? | no <!-- please update UPGRADE-*.md and /CHANGELOG.md files --> |
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", -->           |
| License       | MIT                                                                |

This PR adds a new constraint. It validates a specified document exists, either by field or an instance from the document class.

For instance, we need to be sure that the user who creates a box already exists:

https://github.com/piscibus/siklid-api/blob/25affc50ac9477bfa23c503f310b679ce03934c5/src/Siklid/Document/Box.php#L58-L59