### PR TITLE
[1.x] Fix get config helper

### DIFF
--- a/src/Foundation/Action/AbstractAction.php
+++ b/src/Foundation/Action/AbstractAction.php
@@ -50,6 +50,8 @@ abstract class AbstractAction extends AbstractController implements ActionInterf
         $keyParts = explode('.', $key);
         $config = $this->getParameter($keyParts[0]);
 
+        array_shift($keyParts);
+
         foreach ($keyParts as $keyPart) {
             if (! isset($config[$keyPart])) {
                 return $default;

--- a/src/Foundation/Action/AbstractAction.php
+++ b/src/Foundation/Action/AbstractAction.php
@@ -50,14 +50,12 @@ abstract class AbstractAction extends AbstractController implements ActionInterf
         $keyParts = explode('.', $key);
         $config = $this->getParameter($keyParts[0]);
 
-        array_shift($keyParts);
-
-        foreach ($keyParts as $keyPart) {
-            if (! isset($config[$keyPart])) {
+        for ($i = 1, $iMax = count($keyParts); $i < $iMax; ++$i) {
+            if (! isset($config[$keyParts[$i]])) {
                 return $default;
             }
-
-            $config = $config[$keyPart];
+            assert(is_array($config));
+            $config = $config[$keyParts[$i]];
         }
 
         return $config ?? $default;

--- a/tests/Foundation/Action/AbstractActionTest.php
+++ b/tests/Foundation/Action/AbstractActionTest.php
@@ -65,14 +65,13 @@ class AbstractActionTest extends TestCase
         $container = $this->createMock(ContainerInterface::class);
         $container->method('has')->willReturn(true);
         $parameterBag = $this->createMock(ParameterBag::class);
-        $parameterBag->method('get')->willReturn(['foo' => ['bar' => 'baz']]);
+        $parameterBag->method('get')->willReturn(['bar' => 'baz']);
         $container->method('get')->willReturn($parameterBag);
-
         $sut->setContainer($container);
 
         $this->assertSame('baz', $sut->getConfig('foo.bar'));
         $this->assertSame(['bar' => 'baz'], $sut->getConfig('foo'));
-        $this->assertNull($sut->getConfig('missing'));
+        $this->assertNull($sut->getConfig('foo.missing'));
 
         return $sut;
     }


### PR DESCRIPTION
| Q             | A                                                                  |
|---------------|--------------------------------------------------------------------|
| Branch?       | 1.x <!-- see below -->                                             |
| Bug fix?      | yes                                                            |
| New feature?  | no <!-- please update /CHANGELOG.md files -->                  |
| Deprecations? | no <!-- please update UPGRADE-*.md and /CHANGELOG.md files --> |
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", -->           |
| License       | MIT                                                                |

This PR fixes the get config helper by skipping the first key
