### PR TITLE
[1.x] Add Redis client

### DIFF
--- a/.env
+++ b/.env
@@ -42,3 +42,8 @@ JWT_SECRET_KEY=%kernel.project_dir%/config/jwt/private.pem
 JWT_PUBLIC_KEY=%kernel.project_dir%/config/jwt/public.pem
 JWT_PASSPHRASE=2679490bd10ef0f43a45c2218fdab3e5
 ###< lexik/jwt-authentication-bundle ###
+
+###> Redis ###
+REDIS_HOST=redis
+REDIS_PORT=6379
+###< Redis ###

--- a/.env.test
+++ b/.env.test
@@ -9,3 +9,8 @@ PANTHER_ERROR_SCREENSHOT_DIR=./var/error-screenshots
 MONGODB_URL=mongodb://localhost:27017
 MONGODB_DB=test
 ###< doctrine/mongodb-odm-bundle ###
+
+###> Redis ###
+REDIS_HOST='127.0.0.1'
+REDIS_PORT=6379
+###< Redis ###

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           coverage: "pcov"
           php-version: "${{ matrix.php-version }}"
           ini-values: memory_limit=-1
-          extensions: sodium, fileinfo
+          extensions: sodium, fileinfo, redis
 
       - name: "Start MongoDB"
         uses: supercharge/mongodb-github-action@1.8.0
@@ -74,7 +74,7 @@ jobs:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
           ini-values: memory_limit=-1
-          extensions: sodium, fileinfo
+          extensions: sodium, fileinfo, redis
 
       - name: "Install dependencies"
         uses: "ramsey/composer-install@v2"
@@ -108,7 +108,7 @@ jobs:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
           ini-values: memory_limit=-1
-          extensions: sodium, fileinfo
+          extensions: sodium, fileinfo, redis
 
       - name: "Install dependencies"
         uses: "ramsey/composer-install@v2"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,11 @@ jobs:
           mongodb-version: 6.0
           mongodb-db: test
 
+      - name: "Start Redis"
+        uses: supercharge/redis-github-action@1.4.0
+        with:
+          redis-version: 7.0
+
       - name: "Install dependencies"
         uses: "ramsey/composer-install@v2"
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN set -eux; \
     	apcu \
 		opcache \
         mongodb \
+        redis \
     ;
 
 ###> recipes ###

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
   },
   "config": {
     "platform": {
-      "php": "8.1"
+      "php": "8.1",
+      "ext-mongodb": "1.14.0"
     },
     "allow-plugins": {
       "composer/package-versions-deprecated": true,

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
     "ext-ctype": "*",
     "ext-iconv": "*",
     "ext-mongodb": "*",
+    "ext-redis": "*",
     "beberlei/assert": "^3.3",
     "doctrine/annotations": "^1.0",
     "doctrine/mongodb-odm-bundle": "^4.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e68dff8caa7911ee2ce71dda69743dbe",
+    "content-hash": "f61769e366923e3f4dc4a2bb019ff339",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -1437,22 +1437,22 @@
         },
         {
             "name": "mongodb/mongodb",
-            "version": "1.15.0",
+            "version": "1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mongodb/mongo-php-library.git",
-                "reference": "3a681a3b2f2c0ebac227a3b86bb9057d0e6eb8f8"
+                "reference": "0b8555705d2f9c12ab2e5cebee6b594cdfe6b4e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mongodb/mongo-php-library/zipball/3a681a3b2f2c0ebac227a3b86bb9057d0e6eb8f8",
-                "reference": "3a681a3b2f2c0ebac227a3b86bb9057d0e6eb8f8",
+                "url": "https://api.github.com/repos/mongodb/mongo-php-library/zipball/0b8555705d2f9c12ab2e5cebee6b594cdfe6b4e0",
+                "reference": "0b8555705d2f9c12ab2e5cebee6b594cdfe6b4e0",
                 "shasum": ""
             },
             "require": {
                 "ext-hash": "*",
                 "ext-json": "*",
-                "ext-mongodb": "^1.15.0",
+                "ext-mongodb": "^1.14.0",
                 "jean85/pretty-package-versions": "^1.2 || ^2.0.1",
                 "php": "^7.2 || ^8.0",
                 "symfony/polyfill-php80": "^1.19"
@@ -1460,13 +1460,12 @@
             "require-dev": {
                 "doctrine/coding-standard": "^9.0",
                 "squizlabs/php_codesniffer": "^3.6",
-                "symfony/phpunit-bridge": "^5.2",
-                "vimeo/psalm": "^4.28"
+                "symfony/phpunit-bridge": "^5.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.15.x-dev"
+                    "dev-master": "1.13.x-dev"
                 }
             },
             "autoload": {
@@ -1501,9 +1500,9 @@
             ],
             "support": {
                 "issues": "https://github.com/mongodb/mongo-php-library/issues",
-                "source": "https://github.com/mongodb/mongo-php-library/tree/1.15.0"
+                "source": "https://github.com/mongodb/mongo-php-library/tree/1.13.1"
             },
-            "time": "2022-11-23T04:45:35+00:00"
+            "time": "2022-09-08T03:32:09+00:00"
         },
         {
             "name": "namshi/jose",
@@ -9737,7 +9736,8 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "8.1"
+        "php": "8.1",
+        "ext-mongodb": "1.14.0"
     },
     "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3005c68a029084863e62f05e88255a5c",
+    "content-hash": "e68dff8caa7911ee2ce71dda69743dbe",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -1437,22 +1437,22 @@
         },
         {
             "name": "mongodb/mongodb",
-            "version": "1.13.1",
+            "version": "1.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mongodb/mongo-php-library.git",
-                "reference": "0b8555705d2f9c12ab2e5cebee6b594cdfe6b4e0"
+                "reference": "3a681a3b2f2c0ebac227a3b86bb9057d0e6eb8f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mongodb/mongo-php-library/zipball/0b8555705d2f9c12ab2e5cebee6b594cdfe6b4e0",
-                "reference": "0b8555705d2f9c12ab2e5cebee6b594cdfe6b4e0",
+                "url": "https://api.github.com/repos/mongodb/mongo-php-library/zipball/3a681a3b2f2c0ebac227a3b86bb9057d0e6eb8f8",
+                "reference": "3a681a3b2f2c0ebac227a3b86bb9057d0e6eb8f8",
                 "shasum": ""
             },
             "require": {
                 "ext-hash": "*",
                 "ext-json": "*",
-                "ext-mongodb": "^1.14.0",
+                "ext-mongodb": "^1.15.0",
                 "jean85/pretty-package-versions": "^1.2 || ^2.0.1",
                 "php": "^7.2 || ^8.0",
                 "symfony/polyfill-php80": "^1.19"
@@ -1460,12 +1460,13 @@
             "require-dev": {
                 "doctrine/coding-standard": "^9.0",
                 "squizlabs/php_codesniffer": "^3.6",
-                "symfony/phpunit-bridge": "^5.2"
+                "symfony/phpunit-bridge": "^5.2",
+                "vimeo/psalm": "^4.28"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.13.x-dev"
+                    "dev-master": "1.15.x-dev"
                 }
             },
             "autoload": {
@@ -1500,9 +1501,9 @@
             ],
             "support": {
                 "issues": "https://github.com/mongodb/mongo-php-library/issues",
-                "source": "https://github.com/mongodb/mongo-php-library/tree/1.13.1"
+                "source": "https://github.com/mongodb/mongo-php-library/tree/1.15.0"
             },
-            "time": "2022-09-08T03:32:09+00:00"
+            "time": "2022-11-23T04:45:35+00:00"
         },
         {
             "name": "namshi/jose",
@@ -1897,6 +1898,7 @@
                 "issues": "https://github.com/sensiolabs/SensioFrameworkExtraBundle/issues",
                 "source": "https://github.com/sensiolabs/SensioFrameworkExtraBundle/tree/v6.2.9"
             },
+            "abandoned": "Symfony",
             "time": "2022-11-01T17:17:13+00:00"
         },
         {
@@ -1948,16 +1950,16 @@
         },
         {
             "name": "symfony/cache",
-            "version": "v6.1.7",
+            "version": "v6.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "ee5d5b88162684a1377706f9c25125e97685ee61"
+                "reference": "ffa53c4e0f18828751a57a3f6bc32f7147c03867"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/ee5d5b88162684a1377706f9c25125e97685ee61",
-                "reference": "ee5d5b88162684a1377706f9c25125e97685ee61",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/ffa53c4e0f18828751a57a3f6bc32f7147c03867",
+                "reference": "ffa53c4e0f18828751a57a3f6bc32f7147c03867",
                 "shasum": ""
             },
             "require": {
@@ -2024,7 +2026,7 @@
                 "psr6"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache/tree/v6.1.7"
+                "source": "https://github.com/symfony/cache/tree/v6.1.8"
             },
             "funding": [
                 {
@@ -2040,7 +2042,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-28T16:23:08+00:00"
+            "time": "2022-11-14T10:13:26+00:00"
         },
         {
             "name": "symfony/cache-contracts",
@@ -2200,16 +2202,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.1.7",
+            "version": "v6.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "a1282bd0c096e0bdb8800b104177e2ce404d8815"
+                "reference": "a71863ea74f444d93c768deb3e314e1f750cf20d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/a1282bd0c096e0bdb8800b104177e2ce404d8815",
-                "reference": "a1282bd0c096e0bdb8800b104177e2ce404d8815",
+                "url": "https://api.github.com/repos/symfony/console/zipball/a71863ea74f444d93c768deb3e314e1f750cf20d",
+                "reference": "a71863ea74f444d93c768deb3e314e1f750cf20d",
                 "shasum": ""
             },
             "require": {
@@ -2276,7 +2278,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.1.7"
+                "source": "https://github.com/symfony/console/tree/v6.1.8"
             },
             "funding": [
                 {
@@ -2292,20 +2294,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-26T21:42:49+00:00"
+            "time": "2022-11-25T18:59:16+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v6.1.5",
+            "version": "v6.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "b9c797c9d56afc290d4265854bafd01b4e379240"
+                "reference": "11e33ed84db0ced77511a23b35168db127909f0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/b9c797c9d56afc290d4265854bafd01b4e379240",
-                "reference": "b9c797c9d56afc290d4265854bafd01b4e379240",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/11e33ed84db0ced77511a23b35168db127909f0e",
+                "reference": "11e33ed84db0ced77511a23b35168db127909f0e",
                 "shasum": ""
             },
             "require": {
@@ -2363,7 +2365,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v6.1.5"
+                "source": "https://github.com/symfony/dependency-injection/tree/v6.1.8"
             },
             "funding": [
                 {
@@ -2379,7 +2381,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-09-28T16:00:52+00:00"
+            "time": "2022-11-25T07:34:52+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -2450,16 +2452,16 @@
         },
         {
             "name": "symfony/doctrine-bridge",
-            "version": "v6.1.7",
+            "version": "v6.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/doctrine-bridge.git",
-                "reference": "4b6b99d059333b9fec2d0abbe61ea38573319480"
+                "reference": "088996a46a2561582001153df9c7fab7c065908a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/doctrine-bridge/zipball/4b6b99d059333b9fec2d0abbe61ea38573319480",
-                "reference": "4b6b99d059333b9fec2d0abbe61ea38573319480",
+                "url": "https://api.github.com/repos/symfony/doctrine-bridge/zipball/088996a46a2561582001153df9c7fab7c065908a",
+                "reference": "088996a46a2561582001153df9c7fab7c065908a",
                 "shasum": ""
             },
             "require": {
@@ -2488,7 +2490,7 @@
             },
             "require-dev": {
                 "doctrine/annotations": "^1.10.4",
-                "doctrine/collections": "~1.0",
+                "doctrine/collections": "^1.0|^2.0",
                 "doctrine/data-fixtures": "^1.1",
                 "doctrine/dbal": "^2.13.1|^3.0",
                 "doctrine/orm": "^2.7.4",
@@ -2545,7 +2547,7 @@
             "description": "Provides integration for Doctrine with various Symfony components",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/doctrine-bridge/tree/v6.1.7"
+                "source": "https://github.com/symfony/doctrine-bridge/tree/v6.1.8"
             },
             "funding": [
                 {
@@ -2561,7 +2563,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-15T06:26:03+00:00"
+            "time": "2022-11-28T12:27:40+00:00"
         },
         {
             "name": "symfony/dotenv",
@@ -3063,16 +3065,16 @@
         },
         {
             "name": "symfony/form",
-            "version": "v6.1.7",
+            "version": "v6.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/form.git",
-                "reference": "6f5d13bb996dea03bbb5e43e1bbd90cbfdca1a83"
+                "reference": "821d02c6d3a47bbf38a53f86c1c59e06360f97f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/form/zipball/6f5d13bb996dea03bbb5e43e1bbd90cbfdca1a83",
-                "reference": "6f5d13bb996dea03bbb5e43e1bbd90cbfdca1a83",
+                "url": "https://api.github.com/repos/symfony/form/zipball/821d02c6d3a47bbf38a53f86c1c59e06360f97f4",
+                "reference": "821d02c6d3a47bbf38a53f86c1c59e06360f97f4",
                 "shasum": ""
             },
             "require": {
@@ -3099,7 +3101,7 @@
                 "symfony/twig-bridge": "<5.4"
             },
             "require-dev": {
-                "doctrine/collections": "~1.0",
+                "doctrine/collections": "^1.0|^2.0",
                 "symfony/config": "^5.4|^6.0",
                 "symfony/console": "^5.4|^6.0",
                 "symfony/dependency-injection": "^5.4|^6.0",
@@ -3145,7 +3147,7 @@
             "description": "Allows to easily create, process and reuse HTML forms",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/form/tree/v6.1.7"
+                "source": "https://github.com/symfony/form/tree/v6.1.8"
             },
             "funding": [
                 {
@@ -3161,20 +3163,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-23T10:33:34+00:00"
+            "time": "2022-11-28T12:27:40+00:00"
         },
         {
             "name": "symfony/framework-bundle",
-            "version": "v6.1.7",
+            "version": "v6.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/framework-bundle.git",
-                "reference": "d402e86ce94bb3eb1ca3d6bb0393285c791e2b14"
+                "reference": "0b40e0995acc4686104e8fca126e147c56c35a25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/d402e86ce94bb3eb1ca3d6bb0393285c791e2b14",
-                "reference": "d402e86ce94bb3eb1ca3d6bb0393285c791e2b14",
+                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/0b40e0995acc4686104e8fca126e147c56c35a25",
+                "reference": "0b40e0995acc4686104e8fca126e147c56c35a25",
                 "shasum": ""
             },
             "require": {
@@ -3296,7 +3298,7 @@
             "description": "Provides a tight integration between Symfony components and the Symfony full-stack framework",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/framework-bundle/tree/v6.1.7"
+                "source": "https://github.com/symfony/framework-bundle/tree/v6.1.8"
             },
             "funding": [
                 {
@@ -3312,20 +3314,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-28T16:23:08+00:00"
+            "time": "2022-11-25T18:59:16+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v6.1.7",
+            "version": "v6.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "792a1856d2b95273f0e1c3435785f1d01a60ecc6"
+                "reference": "46b278fb1dae3e65ba30ead50f1c81fbd1c6a79e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/792a1856d2b95273f0e1c3435785f1d01a60ecc6",
-                "reference": "792a1856d2b95273f0e1c3435785f1d01a60ecc6",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/46b278fb1dae3e65ba30ead50f1c81fbd1c6a79e",
+                "reference": "46b278fb1dae3e65ba30ead50f1c81fbd1c6a79e",
                 "shasum": ""
             },
             "require": {
@@ -3371,7 +3373,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v6.1.7"
+                "source": "https://github.com/symfony/http-foundation/tree/v6.1.8"
             },
             "funding": [
                 {
@@ -3387,20 +3389,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-12T09:44:59+00:00"
+            "time": "2022-11-07T08:07:30+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v6.1.7",
+            "version": "v6.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "8fc1ffe753948c47a103a809cdd6a4a8458b3254"
+                "reference": "6073eaed148f4c0b8d4ae33e7332b34327ef728e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/8fc1ffe753948c47a103a809cdd6a4a8458b3254",
-                "reference": "8fc1ffe753948c47a103a809cdd6a4a8458b3254",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/6073eaed148f4c0b8d4ae33e7332b34327ef728e",
+                "reference": "6073eaed148f4c0b8d4ae33e7332b34327ef728e",
                 "shasum": ""
             },
             "require": {
@@ -3481,7 +3483,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v6.1.7"
+                "source": "https://github.com/symfony/http-kernel/tree/v6.1.8"
             },
             "funding": [
                 {
@@ -3497,7 +3499,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-28T18:06:36+00:00"
+            "time": "2022-11-28T18:20:59+00:00"
         },
         {
             "name": "symfony/options-resolver",
@@ -4122,16 +4124,16 @@
         },
         {
             "name": "symfony/property-info",
-            "version": "v6.1.7",
+            "version": "v6.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-info.git",
-                "reference": "b5a46ec66a4b77d4bd39d58c22710be888e55b68"
+                "reference": "f184c96a22554f5a1c518be4564226283ac89a52"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/property-info/zipball/b5a46ec66a4b77d4bd39d58c22710be888e55b68",
-                "reference": "b5a46ec66a4b77d4bd39d58c22710be888e55b68",
+                "url": "https://api.github.com/repos/symfony/property-info/zipball/f184c96a22554f5a1c518be4564226283ac89a52",
+                "reference": "f184c96a22554f5a1c518be4564226283ac89a52",
                 "shasum": ""
             },
             "require": {
@@ -4191,7 +4193,7 @@
                 "validator"
             ],
             "support": {
-                "source": "https://github.com/symfony/property-info/tree/v6.1.7"
+                "source": "https://github.com/symfony/property-info/tree/v6.1.8"
             },
             "funding": [
                 {
@@ -4207,7 +4209,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-28T16:23:08+00:00"
+            "time": "2022-11-25T07:34:52+00:00"
         },
         {
             "name": "symfony/routing",
@@ -5340,16 +5342,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v6.1.6",
+            "version": "v6.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "66c6b0cf52b00f74614a2cf7ae7db08ea1095931"
+                "reference": "20e9985d3fc6a77289102c47b6a110b6fbd24585"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/66c6b0cf52b00f74614a2cf7ae7db08ea1095931",
-                "reference": "66c6b0cf52b00f74614a2cf7ae7db08ea1095931",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/20e9985d3fc6a77289102c47b6a110b6fbd24585",
+                "reference": "20e9985d3fc6a77289102c47b6a110b6fbd24585",
                 "shasum": ""
             },
             "require": {
@@ -5394,7 +5396,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v6.1.6"
+                "source": "https://github.com/symfony/yaml/tree/v6.1.8"
             },
             "funding": [
                 {
@@ -5410,7 +5412,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-07T08:04:03+00:00"
+            "time": "2022-11-25T18:59:16+00:00"
         },
         {
             "name": "voku/portable-ascii",
@@ -7445,12 +7447,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "a1e30f9773206c2740bdb26d564857fe8ee897ae"
+                "reference": "891ecbb72eac808c80fb97f2cce67824e94e5652"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/a1e30f9773206c2740bdb26d564857fe8ee897ae",
-                "reference": "a1e30f9773206c2740bdb26d564857fe8ee897ae",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/891ecbb72eac808c80fb97f2cce67824e94e5652",
+                "reference": "891ecbb72eac808c80fb97f2cce67824e94e5652",
                 "shasum": ""
             },
             "conflict": {
@@ -7475,12 +7477,12 @@
                 "awesome-support/awesome-support": "<=6.0.7",
                 "aws/aws-sdk-php": ">=3,<3.2.1",
                 "backdrop/backdrop": "<=1.23",
-                "badaso/core": "<2.6.1",
+                "badaso/core": "<2.7",
                 "bagisto/bagisto": "<0.1.5",
                 "barrelstrength/sprout-base-email": "<1.2.7",
                 "barrelstrength/sprout-forms": "<3.9",
                 "barryvdh/laravel-translation-manager": "<0.6.2",
-                "baserproject/basercms": "<4.5.4",
+                "baserproject/basercms": "<=4.7.1",
                 "billz/raspap-webgui": "<=2.6.6",
                 "bk2k/bootstrap-package": ">=7.1,<7.1.2|>=8,<8.0.8|>=9,<9.0.4|>=9.1,<9.1.3|>=10,<10.0.10|>=11,<11.0.3",
                 "bmarshall511/wordpress_zero_spam": "<5.2.13",
@@ -7682,7 +7684,7 @@
                 "modx/revolution": "<= 2.8.3-pl|<2.8",
                 "mojo42/jirafeau": "<4.4",
                 "monolog/monolog": ">=1.8,<1.12",
-                "moodle/moodle": "<4.0.1",
+                "moodle/moodle": "<4.0.5",
                 "mustache/mustache": ">=2,<2.14.1",
                 "namshi/jose": "<2.2",
                 "neoan3-apps/template": "<1.1.1",
@@ -7739,6 +7741,7 @@
                 "phpunit/phpunit": ">=4.8.19,<4.8.28|>=5,<5.6.3",
                 "phpwhois/phpwhois": "<=4.2.5",
                 "phpxmlrpc/extras": "<0.6.1",
+                "phpxmlrpc/phpxmlrpc": "<4.9",
                 "pimcore/data-hub": "<1.2.4",
                 "pimcore/pimcore": "<10.5.9",
                 "pocketmine/bedrock-protocol": "<8.0.2",
@@ -7807,6 +7810,7 @@
                 "snipe/snipe-it": "<6.0.11|>= 6.0.0-RC-1, <= 6.0.0-RC-5",
                 "socalnick/scn-social-auth": "<1.15.2",
                 "socialiteproviders/steam": "<1.1",
+                "spatie/browsershot": "<3.57.4",
                 "spipu/html2pdf": "<5.2.4",
                 "spoonity/tcpdf": "<6.2.22",
                 "squizlabs/php_codesniffer": ">=1,<2.8.1|>=3,<3.0.1",
@@ -7978,7 +7982,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-22T19:04:21+00:00"
+            "time": "2022-12-02T23:04:13+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -9245,16 +9249,16 @@
         },
         {
             "name": "symfony/phpunit-bridge",
-            "version": "v6.1.6",
+            "version": "v6.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/phpunit-bridge.git",
-                "reference": "07cf788ac9ae83b59d46599bb5098c3add88c68b"
+                "reference": "1bd3b17db6d2ec284efbdc916600e880d6d858df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/07cf788ac9ae83b59d46599bb5098c3add88c68b",
-                "reference": "07cf788ac9ae83b59d46599bb5098c3add88c68b",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/1bd3b17db6d2ec284efbdc916600e880d6d858df",
+                "reference": "1bd3b17db6d2ec284efbdc916600e880d6d858df",
                 "shasum": ""
             },
             "require": {
@@ -9308,7 +9312,7 @@
             "description": "Provides utilities for PHPUnit, especially user deprecation notices management",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/phpunit-bridge/tree/v6.1.6"
+                "source": "https://github.com/symfony/phpunit-bridge/tree/v6.2.0"
             },
             "funding": [
                 {
@@ -9324,7 +9328,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-07T08:04:03+00:00"
+            "time": "2022-11-18T19:08:09+00:00"
         },
         {
             "name": "symfony/process",
@@ -9728,7 +9732,8 @@
         "php": ">=8.1",
         "ext-ctype": "*",
         "ext-iconv": "*",
-        "ext-mongodb": "*"
+        "ext-mongodb": "*",
+        "ext-redis": "*"
     },
     "platform-dev": [],
     "platform-overrides": {

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -35,3 +35,8 @@ services:
   Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\DoctrineParamConverter:
     arguments:
       $registry: '@doctrine_mongodb'
+
+  Redis:
+    class: Redis
+    calls:
+      - [ connect, [ '%env(REDIS_HOST)%', '%env(REDIS_PORT)%' ] ]

--- a/config/siklid.yaml
+++ b/config/siklid.yaml
@@ -2,3 +2,7 @@ parameters:
   pagination:
     limit: 25
     max_limit: 100
+
+  redis:
+    host: '%env(REDIS_HOST)%'
+    port: '%env(REDIS_PORT)%'

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -1,14 +1,17 @@
 # Development Environment
 
 For development, you will need to install Docker and Docker Composer. You can
-find the installation instructions for your operating system [here](https://docs.docker.com/install/).
+find the installation instructions for your operating
+system [here](https://docs.docker.com/install/).
 
 ## Starting the development environment
 
-[Fork](https://github.com/piscibus/siklid-api/fork) the latest version of this repository and start the docker
+[Fork](https://github.com/piscibus/siklid-api/fork) the latest version of this
+repository and start the docker
 containers:
 
-After cloning the repository, you can start the development environment by running:
+After cloning the repository, you can start the development environment by
+running:
 
 ```bash
 cd siklid-api
@@ -56,8 +59,14 @@ PANTHER_ERROR_SCREENSHOT_DIR=./var/error-screenshots
 
 ###> doctrine/mongodb-odm-bundle ###
 MONGODB_URL=mongodb://root:secret@mongodb:27017
-MONGODB_DB=siklid
+MONGODB_DB=test
 ###< doctrine/mongodb-odm-bundle ###
+
+###> Redis ###
+REDIS_HOST=redis
+REDIS_PORT=6379
+###< Redis ###
+
 
 ```
 
@@ -65,4 +74,5 @@ MONGODB_DB=siklid
 
 ## PHPStorm
 
-- Make sure Xdebug debugging port is set to `9003` not ~~`9000,9003`~~ in PHPStorm settings
+- Make sure Xdebug debugging port is set to `9003` not ~~`9000,9003`~~ in
+  PHPStorm settings

--- a/src/Foundation/Redis/Connection.php
+++ b/src/Foundation/Redis/Connection.php
@@ -12,9 +12,6 @@ class Connection implements ConnectionInterface
 {
     private Redis $redis;
 
-    /**
-     * @psalm-suppress UndefinedClass - Redis class is defined in the extension
-     */
     public function __construct(Redis $redis)
     {
         $this->redis = $redis;

--- a/src/Foundation/Redis/Connection.php
+++ b/src/Foundation/Redis/Connection.php
@@ -64,4 +64,12 @@ class Connection implements ConnectionInterface
     {
         return $this->redis->close();
     }
+
+    /**
+     * @throws RedisException
+     */
+    public function command(string $command, array $args = []): mixed
+    {
+        return $this->redis->rawCommand($command, ...$args);
+    }
 }

--- a/src/Foundation/Redis/Connection.php
+++ b/src/Foundation/Redis/Connection.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Foundation\Redis;
+
+use App\Foundation\Redis\Contract\ConnectionInterface;
+use Redis;
+use RedisException;
+
+/**
+ * @psalm-suppress UndefinedClass - Redis class is defined in the extension
+ */
+class Connection implements ConnectionInterface
+{
+    private Redis $redis;
+
+    /**
+     * @psalm-suppress UndefinedClass - Redis class is defined in the extension
+     */
+    public function __construct(Redis $redis)
+    {
+        $this->redis = $redis;
+    }
+
+    /**
+     * @psalm-suppress MixedArgument - $reserved argument is known to be mixed
+     *
+     * @throws RedisException
+     */
+    public function connect(
+        string $host,
+        int $port = 6379,
+        float $timeout = 0.0,
+        mixed $reserved = null,
+        int $retryInterval = 0,
+        float $readTimeout = 0.0
+    ): void {
+        if (0 !== $retryInterval) {
+            assert(null === $reserved);
+        }
+
+        $this->redis->connect($host, $port, $timeout, $reserved, $retryInterval, $readTimeout);
+    }
+
+    /**
+     * @throws RedisException
+     */
+    public function ping(): string
+    {
+        /** @var true|string $result */
+        $result = $this->redis->ping();
+
+        return true === $result ? 'PONG' : $result;
+    }
+
+    /**
+     * @throws RedisException
+     *
+     * @psalm-suppress MixedInferredReturnType - We know that the result is a boolean
+     * @psalm-suppress MixedReturnStatement - We know that the result is a boolean
+     */
+    public function close(): bool
+    {
+        return $this->redis->close();
+    }
+}

--- a/src/Foundation/Redis/Connection.php
+++ b/src/Foundation/Redis/Connection.php
@@ -8,9 +8,6 @@ use App\Foundation\Redis\Contract\ConnectionInterface;
 use Redis;
 use RedisException;
 
-/**
- * @psalm-suppress UndefinedClass - Redis class is defined in the extension
- */
 class Connection implements ConnectionInterface
 {
     private Redis $redis;

--- a/src/Foundation/Redis/Contract/ConnectionInterface.php
+++ b/src/Foundation/Redis/Contract/ConnectionInterface.php
@@ -4,8 +4,14 @@ declare(strict_types=1);
 
 namespace App\Foundation\Redis\Contract;
 
+/**
+ * Redis connection interface.
+ */
 interface ConnectionInterface
 {
+    /**
+     * Connects to the Redis instance.
+     */
     public function connect(
         string $host,
         int $port = 6379,
@@ -15,7 +21,13 @@ interface ConnectionInterface
         float $readTimeout = 0.0
     ): void;
 
+    /**
+     * Pings the Redis instance.
+     */
     public function ping(): string;
 
+    /**
+     * Closes the connection to the Redis instance.
+     */
     public function close(): bool;
 }

--- a/src/Foundation/Redis/Contract/ConnectionInterface.php
+++ b/src/Foundation/Redis/Contract/ConnectionInterface.php
@@ -30,4 +30,9 @@ interface ConnectionInterface
      * Closes the connection to the Redis instance.
      */
     public function close(): bool;
+
+    /**
+     * Sends a command to the Redis instance.
+     */
+    public function command(string $command, array $args = []): mixed;
 }

--- a/src/Foundation/Redis/Contract/ConnectionInterface.php
+++ b/src/Foundation/Redis/Contract/ConnectionInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Foundation\Redis\Contract;
+
+interface ConnectionInterface
+{
+    public function connect(
+        string $host,
+        int $port = 6379,
+        float $timeout = 0.0,
+        mixed $reserved = null,
+        int $retryInterval = 0,
+        float $readTimeout = 0.0
+    ): void;
+
+    public function ping(): string;
+
+    public function close(): bool;
+}

--- a/src/Foundation/Redis/Contract/SetInterface.php
+++ b/src/Foundation/Redis/Contract/SetInterface.php
@@ -33,4 +33,14 @@ interface SetInterface
      * Removes the specified members from the set stored at key.
      */
     public function remove(string $sutKey, ...$members): int;
+
+    /**
+     * Gets the number of seconds until the key will expire.
+     */
+    public function getTtl(string $key): int;
+
+    /**
+     * Sets the number of seconds until the key will expire.
+     */
+    public function setTtl(string $key, int $ttl): bool;
 }

--- a/src/Foundation/Redis/Contract/SetInterface.php
+++ b/src/Foundation/Redis/Contract/SetInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Foundation\Redis\Contract;
+
+/**
+ * @psalm-suppress MissingParamType
+ */
+interface SetInterface
+{
+    /**
+     * Gets the number of members in a set.
+     */
+    public function size(string $key): int;
+
+    /**
+     * Adds the specified members to the set stored at key.
+     */
+    public function add(string $key, ...$members): int;
+
+    /**
+     * Returns if member is a member of the set stored at key.
+     */
+    public function contains(string $key, string $needle): bool;
+
+    /**
+     * Returns all the members of the set value stored at key.
+     */
+    public function members(string $key): array;
+
+    /**
+     * Removes the specified members from the set stored at key.
+     */
+    public function remove(string $sutKey, ...$members): int;
+}

--- a/src/Foundation/Redis/Set.php
+++ b/src/Foundation/Redis/Set.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Foundation\Redis;
+
+use App\Foundation\Redis\Contract\ConnectionInterface;
+use App\Foundation\Redis\Contract\SetInterface;
+
+/**
+ * @psalm-suppress MissingParamType
+ */
+class Set implements SetInterface
+{
+    private ConnectionInterface $connection;
+
+    public function __construct(ConnectionInterface $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function size(string $key): int
+    {
+        return (int)$this->connection->command('SCARD', [$key]);
+    }
+
+    public function add(string $key, ...$members): int
+    {
+        foreach ($members as $member) {
+            assert(is_string($member));
+        }
+
+        return (int)$this->connection->command('SADD', array_merge([$key], $members));
+    }
+
+    public function contains(string $key, string $needle): bool
+    {
+        return (bool)$this->connection->command('SISMEMBER', [$key, $needle]);
+    }
+
+    public function members(string $key): array
+    {
+        return (array)$this->connection->command('SMEMBERS', [$key]);
+    }
+
+    public function remove(string $sutKey, ...$members): int
+    {
+        foreach ($members as $member) {
+            assert(is_string($member));
+        }
+
+        return (int)$this->connection->command('SREM', array_merge([$sutKey], $members));
+    }
+}

--- a/src/Foundation/Redis/Set.php
+++ b/src/Foundation/Redis/Set.php
@@ -77,4 +77,26 @@ class Set implements SetInterface
 
         return (int)$count;
     }
+
+    /**
+     * @throws RedisException
+     */
+    public function getTtl(string $key): int
+    {
+        $ttl = $this->redis->ttl($key);
+        assert(! $ttl instanceof Redis);
+
+        return (int)$ttl;
+    }
+
+    /**
+     * @throws RedisException
+     */
+    public function setTtl(string $key, int $ttl): bool
+    {
+        $response = $this->redis->expire($key, $ttl);
+        assert(! $response instanceof Redis);
+
+        return $response;
+    }
 }

--- a/tests/Concern/Assertion/AssertArrayTrait.php
+++ b/tests/Concern/Assertion/AssertArrayTrait.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Concern\Assertion;
+
+use App\Tests\TestCase;
+
+/**
+ * @mixin TestCase
+ */
+trait AssertArrayTrait
+{
+    /**
+     * Asserts that two arrays have the same keys and values.
+     */
+    protected function assertArrayEquals(array $expected, array $actual): void
+    {
+        $this->assertSameSize($expected, $actual);
+        $this->assertEmpty(array_diff($expected, $actual));
+    }
+}

--- a/tests/Concern/KernelTestCaseTrait.php
+++ b/tests/Concern/KernelTestCaseTrait.php
@@ -285,4 +285,30 @@ trait KernelTestCaseTrait
             $this->dropCollection($class);
         }
     }
+
+    /**
+     * Returns the value of the given parameter.
+     *
+     * @return mixed The value of the parameter
+     *
+     * @psalm-suppress PossiblyUndefinedMethod - The user should know about the config values
+     * @psalm-suppress MixedAssignment - Expected to be mixed
+     */
+    public function getConfig(string $key, mixed $default = null): mixed
+    {
+        $keyParts = explode('.', $key);
+        $config = $this->container()->getParameter($keyParts[0]);
+
+        array_shift($keyParts);
+
+        foreach ($keyParts as $keyPart) {
+            if (! isset($config[$keyPart])) {
+                return $default;
+            }
+
+            $config = $config[$keyPart];
+        }
+
+        return $config ?? $default;
+    }
 }

--- a/tests/Concern/KernelTestCaseTrait.php
+++ b/tests/Concern/KernelTestCaseTrait.php
@@ -299,14 +299,12 @@ trait KernelTestCaseTrait
         $keyParts = explode('.', $key);
         $config = $this->container()->getParameter($keyParts[0]);
 
-        array_shift($keyParts);
-
-        foreach ($keyParts as $keyPart) {
-            if (! isset($config[$keyPart])) {
+        for ($i = 1, $iMax = count($keyParts); $i < $iMax; ++$i) {
+            if (! isset($config[$keyParts[$i]])) {
                 return $default;
             }
-
-            $config = $config[$keyPart];
+            assert(is_array($config));
+            $config = $config[$keyParts[$i]];
         }
 
         return $config ?? $default;

--- a/tests/Foundation/Redis/ConnectionTest.php
+++ b/tests/Foundation/Redis/ConnectionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Foundation\Redis;
 
 use App\Foundation\Redis\Connection;
+use App\Foundation\Redis\Contract\ConnectionInterface;
 use App\Tests\Concern\KernelTestCaseTrait;
 use PHPUnit\Framework\TestCase;
 use Redis;
@@ -19,15 +20,15 @@ class ConnectionTest extends TestCase
 {
     use KernelTestCaseTrait;
 
-    private Connection $sut;
+    private ConnectionInterface $sut;
 
     private string $host;
 
     public function setUp(): void
     {
-        $this->sut = new Connection(new Redis());
-
         $this->host = (string)$this->getConfig('redis.host');
+
+        $this->sut = new Connection(new Redis());
     }
 
     /**

--- a/tests/Foundation/Redis/ConnectionTest.php
+++ b/tests/Foundation/Redis/ConnectionTest.php
@@ -80,4 +80,16 @@ class ConnectionTest extends TestCase
     {
         $this->assertIsBool($this->sut->close());
     }
+
+    /**
+     * @test
+     *
+     * @throws RedisException
+     */
+    public function command(): void
+    {
+        $this->sut->connect($this->host);
+
+        $this->assertTrue($this->sut->command('ping'));
+    }
 }

--- a/tests/Foundation/Redis/ConnectionTest.php
+++ b/tests/Foundation/Redis/ConnectionTest.php
@@ -15,7 +15,7 @@ use RedisException;
  * @psalm-suppress MixedArgument - Redis class is defined in the extension
  * @psalm-suppress UndefinedClass - Redis class is defined in the extension
  */
-class RedisConnectionTest extends TestCase
+class ConnectionTest extends TestCase
 {
     use KernelTestCaseTrait;
 

--- a/tests/Foundation/Redis/RedisConnectionTest.php
+++ b/tests/Foundation/Redis/RedisConnectionTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Foundation\Redis;
+
+use App\Foundation\Redis\Connection;
+use App\Tests\Concern\KernelTestCaseTrait;
+use PHPUnit\Framework\TestCase;
+use Redis;
+use RedisException;
+
+/**
+ * @psalm-suppress MissingConstructor
+ * @psalm-suppress MixedArgument - Redis class is defined in the extension
+ * @psalm-suppress UndefinedClass - Redis class is defined in the extension
+ */
+class RedisConnectionTest extends TestCase
+{
+    use KernelTestCaseTrait;
+
+    private Connection $sut;
+
+    private string $host;
+
+    public function setUp(): void
+    {
+        $this->sut = new Connection(new Redis());
+
+        $this->host = (string)$this->getConfig('redis.host');
+    }
+
+    /**
+     * @test
+     *
+     * @throws RedisException
+     */
+    public function connect(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $this->sut->connect($this->host);
+    }
+
+    /**
+     * @test
+     *
+     * @psalm-suppress MixedArgument - RedisException class is defined in the extension
+     * @psalm-suppress InvalidArgument - RedisException is throwable
+     * @psalm-suppress UndefinedClass - RedisException class is defined in the extension
+     */
+    public function connect_with_invalid_host(): void
+    {
+        $this->expectException(RedisException::class);
+
+        $this->sut->connect('invalid-host');
+    }
+
+    /**
+     * @test
+     *
+     * @throws RedisException
+     */
+    public function ping(): void
+    {
+        $this->sut->connect($this->host);
+
+        $actual = $this->sut->ping();
+
+        $this->assertSame('PONG', $actual);
+    }
+
+    /**
+     * @test
+     *
+     * @throws RedisException
+     */
+    public function close(): void
+    {
+        $this->assertIsBool($this->sut->close());
+    }
+}

--- a/tests/Foundation/Redis/SetTest.php
+++ b/tests/Foundation/Redis/SetTest.php
@@ -110,6 +110,30 @@ class SetTest extends TestCase
     }
 
     /**
+     * @test
+     */
+    public function get_ttl(): void
+    {
+        $sut = new Set($this->redis);
+        $sut->add($this->sutKey, 'member1', 'member2', 'member3');
+
+        $this->assertSame(-1, $sut->getTtl($this->sutKey));
+    }
+
+    /**
+     * @test
+     */
+    public function set_ttl(): void
+    {
+        $sut = new Set($this->redis);
+        $sut->add($this->sutKey, 'member1', 'member2', 'member3');
+
+        $sut->setTtl($this->sutKey, 10);
+
+        $this->assertSame(10, $sut->getTtl($this->sutKey));
+    }
+
+    /**
      * {@inheritDoc}
      *
      * @throws RedisException

--- a/tests/Foundation/Redis/SetTest.php
+++ b/tests/Foundation/Redis/SetTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Foundation\Redis;
+
+use App\Foundation\Redis\Connection;
+use App\Foundation\Redis\Contract\ConnectionInterface;
+use App\Foundation\Redis\Set;
+use App\Tests\Concern\KernelTestCaseTrait;
+use App\Tests\TestCase;
+use Redis;
+use RedisException;
+
+/**
+ * @psalm-suppress MissingConstructor
+ * @psalm-suppress UndefinedClass
+ */
+class SetTest extends TestCase
+{
+    use KernelTestCaseTrait;
+
+    private ConnectionInterface $connection;
+
+    private string $sutKey = 'test:redis:set';
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws RedisException
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connection = new Connection(new Redis());
+        $this->connection->connect((string)$this->getConfig('redis.host'));
+    }
+
+    /**
+     * @test
+     */
+    public function size(): void
+    {
+        $sut = new Set($this->connection);
+
+        $this->assertSame(0, $sut->size($this->sutKey));
+    }
+
+    /**
+     * @test
+     */
+    public function add(): void
+    {
+        $sut = new Set($this->connection);
+        $added = $sut->add($this->sutKey, 'member1', 'member2', 'member3');
+
+        $this->assertSame(3, $added);
+        $this->assertSame(3, $sut->size($this->sutKey));
+        $this->assertSame(0, $sut->add($this->sutKey, 'member1', 'member2', 'member3'));
+    }
+
+    /**
+     * @test
+     */
+    public function contains(): void
+    {
+        $sut = new Set($this->connection);
+        $sut->add($this->sutKey, 'member1', 'member2', 'member3');
+
+        $this->assertTrue($sut->contains($this->sutKey, 'member1'));
+        $this->assertTrue($sut->contains($this->sutKey, 'member2'));
+        $this->assertTrue($sut->contains($this->sutKey, 'member3'));
+        $this->assertFalse($sut->contains($this->sutKey, 'member4'));
+    }
+
+    /**
+     * @test
+     */
+    public function members(): void
+    {
+        $sut = new Set($this->connection);
+        $sut->add($this->sutKey, 'member1', 'member2', 'member3');
+
+        $this->assertArrayEquals(['member1', 'member2', 'member3'], $sut->members($this->sutKey));
+    }
+
+    /**
+     * @test
+     */
+    public function remove(): void
+    {
+        $sut = new Set($this->connection);
+        $sut->add($this->sutKey, 'member1', 'member2', 'member3');
+
+        $removed = $sut->remove($this->sutKey, 'member1', 'member2');
+
+        $this->assertSame(2, $removed);
+        $this->assertSame(1, $sut->size($this->sutKey));
+        $this->assertArrayEquals(['member3'], $sut->members($this->sutKey));
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws RedisException
+     */
+    protected function tearDown(): void
+    {
+        $this->connection->command('del', [$this->sutKey]);
+
+        parent::tearDown();
+    }
+}

--- a/tests/Foundation/Redis/SetTest.php
+++ b/tests/Foundation/Redis/SetTest.php
@@ -111,6 +111,8 @@ class SetTest extends TestCase
 
     /**
      * @test
+     *
+     * @throws RedisException
      */
     public function get_ttl(): void
     {
@@ -122,6 +124,8 @@ class SetTest extends TestCase
 
     /**
      * @test
+     *
+     * @throws RedisException
      */
     public function set_ttl(): void
     {

--- a/tests/Foundation/Redis/SetTest.php
+++ b/tests/Foundation/Redis/SetTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace App\Tests\Foundation\Redis;
 
-use App\Foundation\Redis\Connection;
-use App\Foundation\Redis\Contract\ConnectionInterface;
 use App\Foundation\Redis\Set;
 use App\Tests\Concern\KernelTestCaseTrait;
 use App\Tests\TestCase;
@@ -20,7 +18,7 @@ class SetTest extends TestCase
 {
     use KernelTestCaseTrait;
 
-    private ConnectionInterface $connection;
+    private Redis $redis;
 
     private string $sutKey = 'test:redis:set';
 
@@ -33,26 +31,31 @@ class SetTest extends TestCase
     {
         parent::setUp();
 
-        $this->connection = new Connection(new Redis());
-        $this->connection->connect((string)$this->getConfig('redis.host'));
+        $this->redis = new Redis();
+        $host = (string)$this->getConfig('redis.host');
+        $this->redis->connect($host);
     }
 
     /**
      * @test
+     *
+     * @throws RedisException
      */
     public function size(): void
     {
-        $sut = new Set($this->connection);
+        $sut = new Set($this->redis);
 
         $this->assertSame(0, $sut->size($this->sutKey));
     }
 
     /**
      * @test
+     *
+     * @throws RedisException
      */
     public function add(): void
     {
-        $sut = new Set($this->connection);
+        $sut = new Set($this->redis);
         $added = $sut->add($this->sutKey, 'member1', 'member2', 'member3');
 
         $this->assertSame(3, $added);
@@ -62,10 +65,12 @@ class SetTest extends TestCase
 
     /**
      * @test
+     *
+     * @throws RedisException
      */
     public function contains(): void
     {
-        $sut = new Set($this->connection);
+        $sut = new Set($this->redis);
         $sut->add($this->sutKey, 'member1', 'member2', 'member3');
 
         $this->assertTrue($sut->contains($this->sutKey, 'member1'));
@@ -76,10 +81,12 @@ class SetTest extends TestCase
 
     /**
      * @test
+     *
+     * @throws RedisException
      */
     public function members(): void
     {
-        $sut = new Set($this->connection);
+        $sut = new Set($this->redis);
         $sut->add($this->sutKey, 'member1', 'member2', 'member3');
 
         $this->assertArrayEquals(['member1', 'member2', 'member3'], $sut->members($this->sutKey));
@@ -87,10 +94,12 @@ class SetTest extends TestCase
 
     /**
      * @test
+     *
+     * @throws RedisException
      */
     public function remove(): void
     {
-        $sut = new Set($this->connection);
+        $sut = new Set($this->redis);
         $sut->add($this->sutKey, 'member1', 'member2', 'member3');
 
         $removed = $sut->remove($this->sutKey, 'member1', 'member2');
@@ -107,7 +116,7 @@ class SetTest extends TestCase
      */
     protected function tearDown(): void
     {
-        $this->connection->command('del', [$this->sutKey]);
+        $this->redis->del($this->sutKey);
 
         parent::tearDown();
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests;
 
+use App\Tests\Concern\Assertion\AssertArrayTrait;
 use App\Tests\Concern\Assertion\AssertAttributeTrait;
 use Doctrine\ODM\MongoDB\Types\Type;
 use ReflectionClass;
@@ -18,6 +19,7 @@ use ReflectionMethod;
 abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
     use AssertAttributeTrait;
+    use AssertArrayTrait;
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
| Q             | A                                                                  |
|---------------|--------------------------------------------------------------------|
| Branch?       | 1.x <!-- see below -->                                             |
| Bug fix?      | no                                                            |
| New feature?  | yes <!-- please update /CHANGELOG.md files -->                  |
| Deprecations? | no <!-- please update UPGRADE-*.md and /CHANGELOG.md files --> |
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", -->           |
| License       | MIT                                                                |

This PR adds wrapper classes around the Redis classes provided by the [phpredis](https://github.com/phpredis/phpredis) extension.
The wrapper classes are meant to be used directly by dependency injection containers and other framework components.

For instance, you can use the `Set` class in your controller as follows:

```php
public function indexAction(SetInterface $set)
{
    $setKey = 'myKey';
    $set->add($setKey, 'foo');
    $set->add($setKey, 'bar');

    $values = $set->members($setKey);

    // $values contains ['foo', 'bar']
}
```

The implemented wrapper classes are:

- `Connection`: That helps connect to a Redis server.
- `Set`: That helps using Redis sets.

More wrapper classes will be added in the future.