### PR TITLE
[1.x] implement user resolver

### DIFF
--- a/src/Siklid/Security/UserResolver.php
+++ b/src/Siklid/Security/UserResolver.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Siklid\Security;
+
+use App\Siklid\Application\Contract\Entity\UserInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+class UserResolver implements UserResolverInterface
+{
+    private TokenStorageInterface $tokenStorage;
+
+    public function __construct(TokenStorageInterface $tokenStorage)
+    {
+        $this->tokenStorage = $tokenStorage;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUser(): ?UserInterface
+    {
+        $user = $this->tokenStorage->getToken()?->getUser();
+        assert($user instanceof UserInterface || null === $user);
+
+        return $user;
+    }
+}

--- a/src/Siklid/Security/UserResolverInterface.php
+++ b/src/Siklid/Security/UserResolverInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Siklid\Security;
+
+use App\Siklid\Application\Contract\Entity\UserInterface;
+
+interface UserResolverInterface
+{
+    /**
+     * Returns current user.
+     */
+    public function getUser(): ?UserInterface;
+}

--- a/tests/Siklid/Security/UserResolverTest.php
+++ b/tests/Siklid/Security/UserResolverTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Siklid\Security;
+
+use App\Siklid\Document\User;
+use App\Siklid\Security\UserResolver;
+use App\Tests\Concern\KernelTestCaseTrait;
+use App\Tests\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+class UserResolverTest extends TestCase
+{
+    use KernelTestCaseTrait;
+
+    /**
+     * @test
+     */
+    public function get_user_returns_null_with_no_active_user(): void
+    {
+        /** @var TokenStorageInterface $tokenStorage */
+        $tokenStorage = $this->container()->get('security.token_storage');
+        $sut = new UserResolver($tokenStorage);
+
+        $actual = $sut->getUser();
+
+        self::assertNull($actual);
+    }
+
+    /**
+     * @test
+     */
+    public function get_user_returns_the_current_user(): void
+    {
+        $user = new User();
+        $token = $this->createMock(TokenInterface::class);
+        $token->method('getUser')->willReturn($user);
+        $tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $tokenStorage->method('getToken')->willReturn($token);
+        $sut = new UserResolver($tokenStorage);
+
+        $actual = $sut->getUser();
+
+        $this->assertSame($user, $actual);
+    }
+}


### PR DESCRIPTION
| Q             | A                                                                  |
|---------------|--------------------------------------------------------------------|
| Branch?       | 1.x <!-- see below -->                                             |
| Bug fix?      | no                                                            |
| New feature?  | yes <!-- please update /CHANGELOG.md files -->                  |
| Deprecations? | no <!-- please update UPGRADE-*.md and /CHANGELOG.md files --> |
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", -->           |
| License       | MIT                                                                |

This PR adds a user resolver service. This service can be used to get the currently active user.

This is one of the steps to make the business layer (Action) independent of the presentation layer (Controller). Reported in #165 