### PR TITLE
[1.x] Add config helper

### DIFF
--- a/src/Foundation/Action/AbstractAction.php
+++ b/src/Foundation/Action/AbstractAction.php
@@ -18,30 +18,6 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 abstract class AbstractAction extends AbstractController implements ActionInterface
 {
     /**
-     * Returns the value of the given parameter.
-     *
-     * @return mixed The value of the parameter
-     *
-     * @psalm-suppress PossiblyUndefinedMethod - The user should know about the config values
-     * @psalm-suppress MixedAssignment - Expected to be mixed
-     */
-    public function getConfig(string $key, mixed $default = null): mixed
-    {
-        $keyParts = explode('.', $key);
-        $config = $this->getParameter($keyParts[0]);
-
-        for ($i = 1, $iMax = count($keyParts); $i < $iMax; ++$i) {
-            if (! isset($config[$keyParts[$i]])) {
-                return $default;
-            }
-            assert(is_array($config));
-            $config = $config[$keyParts[$i]];
-        }
-
-        return $config ?? $default;
-    }
-
-    /**
      * Creates a new form instance from the given type.
      *
      * @template       T

--- a/src/Foundation/Action/Config.php
+++ b/src/Foundation/Action/Config.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Foundation\Action;
+
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ContainerBag;
+use UnitEnum;
+
+class Config implements ConfigInterface
+{
+    private ContainerBag $config;
+
+    public function __construct(ContainerBag $config)
+    {
+        $this->config = $config;
+    }
+
+    public function all(): array
+    {
+        return $this->config->all();
+    }
+
+    /**
+     * @psalm-suppress MixedInferredReturnType - Mixed values are expected.
+     * @psalm-suppress MixedAssignment
+     * @psalm-suppress MixedReturnStatement
+     */
+    public function get(string $key, mixed $default = null): array|bool|string|int|float|UnitEnum|null
+    {
+        assert(
+            is_array($default) ||
+            is_scalar($default) ||
+            is_null($default) ||
+            $default instanceof UnitEnum
+        );
+
+        $keyParts = explode('.', $key);
+        try {
+            $config = $this->config->get($keyParts[0]);
+        } catch (NotFoundExceptionInterface|ContainerExceptionInterface) {
+            return $default;
+        }
+
+        for ($i = 1, $iMax = count($keyParts); $i < $iMax; ++$i) {
+            if ($config instanceof UnitEnum || ! isset($config[$keyParts[$i]])) {
+                return $default;
+            }
+            assert(is_array($config));
+            $config = $config[$keyParts[$i]];
+        }
+
+        return $config ?? $default;
+    }
+
+    public function has(string $key): bool
+    {
+        return $this->config->has($key);
+    }
+}

--- a/src/Foundation/Action/Config.php
+++ b/src/Foundation/Action/Config.php
@@ -4,16 +4,15 @@ declare(strict_types=1);
 
 namespace App\Foundation\Action;
 
-use Psr\Container\ContainerExceptionInterface;
-use Psr\Container\NotFoundExceptionInterface;
-use Symfony\Component\DependencyInjection\ParameterBag\ContainerBag;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use UnitEnum;
 
 class Config implements ConfigInterface
 {
-    private ContainerBag $config;
+    private ParameterBagInterface $config;
 
-    public function __construct(ContainerBag $config)
+    public function __construct(ParameterBagInterface $config)
     {
         $this->config = $config;
     }
@@ -28,7 +27,7 @@ class Config implements ConfigInterface
      * @psalm-suppress MixedAssignment
      * @psalm-suppress MixedReturnStatement
      */
-    public function get(string $key, mixed $default = null): array|bool|string|int|float|UnitEnum|null
+    public function get(string $key, mixed $default = null): mixed
     {
         assert(
             is_array($default) ||
@@ -40,7 +39,7 @@ class Config implements ConfigInterface
         $keyParts = explode('.', $key);
         try {
             $config = $this->config->get($keyParts[0]);
-        } catch (NotFoundExceptionInterface|ContainerExceptionInterface) {
+        } catch (InvalidArgumentException) {
             return $default;
         }
 

--- a/src/Foundation/Action/ConfigInterface.php
+++ b/src/Foundation/Action/ConfigInterface.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace App\Foundation\Action;
 
-use UnitEnum;
-
 interface ConfigInterface
 {
     /**
@@ -16,10 +14,7 @@ interface ConfigInterface
     /**
      * Finds a parameter by name.
      */
-    public function get(
-        string $key,
-        array|bool|string|int|float|UnitEnum|null $default = null
-    ): array|bool|string|int|float|UnitEnum|null;
+    public function get(string $key, mixed $default = null): mixed;
 
     /**
      * Returns true if the parameter exists.

--- a/src/Foundation/Action/ConfigInterface.php
+++ b/src/Foundation/Action/ConfigInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Foundation\Action;
+
+use UnitEnum;
+
+interface ConfigInterface
+{
+    /**
+     * Returns all parameters.
+     */
+    public function all(): array;
+
+    /**
+     * Finds a parameter by name.
+     */
+    public function get(
+        string $key,
+        array|bool|string|int|float|UnitEnum|null $default = null
+    ): array|bool|string|int|float|UnitEnum|null;
+
+    /**
+     * Returns true if the parameter exists.
+     */
+    public function has(string $key): bool;
+}

--- a/src/Siklid/Application/Box/ListBoxes.php
+++ b/src/Siklid/Application/Box/ListBoxes.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Siklid\Application\Box;
 
 use App\Foundation\Action\AbstractAction;
+use App\Foundation\Action\ConfigInterface;
 use App\Foundation\Exception\ValidationException;
 use App\Foundation\Http\Request;
 use App\Foundation\Pagination\Contract\PageInterface;
@@ -20,11 +21,13 @@ final class ListBoxes extends AbstractAction
     private DocumentManager $dm;
 
     private Request $request;
+    private ConfigInterface $config;
 
-    public function __construct(DocumentManager $dm, Request $request)
+    public function __construct(DocumentManager $dm, Request $request, ConfigInterface $config)
     {
         $this->dm = $dm;
         $this->request = $request;
+        $this->config = $config;
     }
 
     public function execute(): PageInterface
@@ -45,7 +48,7 @@ final class ListBoxes extends AbstractAction
             throw new ValidationException('Size must be 1 or greater.');
         }
 
-        $maxSize = (int)$this->getConfig('pagination.max_limit', 100);
+        $maxSize = (int)$this->config->get('pagination.max_limit', 100);
         if ($limit > $maxSize) {
             throw new ValidationException("Size must be less than or equal to $maxSize.");
         }
@@ -69,7 +72,7 @@ final class ListBoxes extends AbstractAction
 
     private function getLimit(): int
     {
-        $limit = (int)$this->getConfig('pagination.limit', 25);
+        $limit = (int)$this->config->get('pagination.limit', 25);
 
         if ($this->request->has('size')) {
             $limit = (int)$this->request->get('size');

--- a/tests/Concern/KernelTestCaseTrait.php
+++ b/tests/Concern/KernelTestCaseTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Concern;
 
+use App\Foundation\Action\Config;
 use App\Tests\Concern\Assertion\AssertODMTrait;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
@@ -19,6 +20,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\DependencyInjection\ParameterBag\ContainerBag;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Contracts\Service\ResetInterface;
 
@@ -296,17 +298,9 @@ trait KernelTestCaseTrait
      */
     public function getConfig(string $key, mixed $default = null): mixed
     {
-        $keyParts = explode('.', $key);
-        $config = $this->container()->getParameter($keyParts[0]);
+        /** @var ContainerBag $parameterBag */
+        $parameterBag = $this->container()->get('parameter_bag');
 
-        for ($i = 1, $iMax = count($keyParts); $i < $iMax; ++$i) {
-            if (! isset($config[$keyParts[$i]])) {
-                return $default;
-            }
-            assert(is_array($config));
-            $config = $config[$keyParts[$i]];
-        }
-
-        return $config ?? $default;
+        return (new Config($parameterBag))->get($key, $default);
     }
 }

--- a/tests/Foundation/Action/AbstractActionTest.php
+++ b/tests/Foundation/Action/AbstractActionTest.php
@@ -6,54 +6,12 @@ namespace App\Tests\Foundation\Action;
 
 use App\Foundation\Action\AbstractAction;
 use App\Tests\TestCase;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
 /**
  * @psalm-suppress MissingConstructor
  */
 class AbstractActionTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function get_config(): AbstractAction
-    {
-        $sut = $this->getMockForAbstractClass(AbstractAction::class);
-        $container = $this->createMock(ContainerInterface::class);
-        $container->method('has')->willReturn(true);
-        $parameterBag = $this->createMock(ParameterBag::class);
-        $parameterBag->method('get')->willReturn(['bar' => 'baz']);
-        $container->method('get')->willReturn($parameterBag);
-        $sut->setContainer($container);
-
-        $this->assertSame('baz', $sut->getConfig('foo.bar'));
-        $this->assertSame(['bar' => 'baz'], $sut->getConfig('foo'));
-        $this->assertNull($sut->getConfig('foo.missing'));
-
-        return $sut;
-    }
-
-    /**
-     * @test
-     *
-     * @depends get_config
-     */
-    public function get_config_returns_null_by_default(AbstractAction $sut): void
-    {
-        $this->assertNull($sut->getConfig('foo.missing'));
-    }
-
-    /**
-     * @test
-     *
-     * @depends get_config
-     */
-    public function get_config_can_accept_a_default_value(AbstractAction $sut): void
-    {
-        $this->assertSame('default', $sut->getConfig('foo.missing', 'default'));
-    }
-
     /**
      * @test
      */

--- a/tests/Foundation/Action/ConfigTest.php
+++ b/tests/Foundation/Action/ConfigTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Foundation\Action;
+
+use App\Foundation\Action\Config;
+use App\Tests\Concern\KernelTestCaseTrait;
+use App\Tests\TestCase;
+use Symfony\Component\DependencyInjection\ParameterBag\ContainerBag;
+
+class ConfigTest extends TestCase
+{
+    use KernelTestCaseTrait;
+
+    /**
+     * @test
+     */
+    public function all(): void
+    {
+        $containerBag = $this->createMock(ContainerBag::class);
+        $containerBag->expects($this->once())->method('all')->willReturn(['foo' => 'bar']);
+        $sut = new Config($containerBag);
+
+        $actual = $sut->all();
+
+        $this->assertSame(['foo' => 'bar'], $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function has(): void
+    {
+        $containerBag = $this->createMock(ContainerBag::class);
+        $containerBag->expects($this->exactly(2))->method('has')->willReturnMap([
+            ['foo', true],
+            ['bar', false],
+        ]);
+        $containerBag->expects($this->never())->method('get');
+        $sut = new Config($containerBag);
+
+        $this->assertTrue($sut->has('foo'));
+        $this->assertFalse($sut->has('bar'));
+    }
+
+    /**
+     * @test
+     */
+    public function get(): void
+    {
+        $containerBag = $this->createMock(ContainerBag::class);
+        $containerBag->expects($this->once())->method('get')->with('foo')->willReturn('bar');
+        $sut = new Config($containerBag);
+
+        $actual = $sut->get('foo');
+
+        $this->assertSame('bar', $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function access_parameters_by_period_separator(): void
+    {
+        $containerBag = $this->createMock(ContainerBag::class);
+        $containerBag->expects($this->once())->method('get')->with('foo')->willReturn(['bar' => 'baz']);
+        $sut = new Config($containerBag);
+
+        $actual = $sut->get('foo.bar');
+
+        $this->assertSame('baz', $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function get_returns_default_value_if_value_is_missed(): void
+    {
+        /** @var ContainerBag $parameterBag */
+        $parameterBag = $this->container()->get('parameter_bag');
+        $sut = new Config($parameterBag);
+
+        $actual = $sut->get('foo.bar', 'default');
+
+        $this->assertSame('default', $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function get_returns_default_value_if_nested_parameter_is_missed(): void
+    {
+        $parameterBag = $this->createMock(ContainerBag::class);
+        $parameterBag->expects($this->once())->method('get')->with('foo')->willReturn(['bar' => 'baz']);
+        $sut = new Config($parameterBag);
+
+        $actual = $sut->get('foo.baz', 'default');
+
+        $this->assertSame('default', $actual);
+    }
+}

--- a/tests/Foundation/Action/ConfigTest.php
+++ b/tests/Foundation/Action/ConfigTest.php
@@ -7,7 +7,7 @@ namespace App\Tests\Foundation\Action;
 use App\Foundation\Action\Config;
 use App\Tests\Concern\KernelTestCaseTrait;
 use App\Tests\TestCase;
-use Symfony\Component\DependencyInjection\ParameterBag\ContainerBag;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 class ConfigTest extends TestCase
 {
@@ -18,9 +18,9 @@ class ConfigTest extends TestCase
      */
     public function all(): void
     {
-        $containerBag = $this->createMock(ContainerBag::class);
-        $containerBag->expects($this->once())->method('all')->willReturn(['foo' => 'bar']);
-        $sut = new Config($containerBag);
+        $parameterBag = $this->createMock(ParameterBagInterface::class);
+        $parameterBag->expects($this->once())->method('all')->willReturn(['foo' => 'bar']);
+        $sut = new Config($parameterBag);
 
         $actual = $sut->all();
 
@@ -32,13 +32,13 @@ class ConfigTest extends TestCase
      */
     public function has(): void
     {
-        $containerBag = $this->createMock(ContainerBag::class);
-        $containerBag->expects($this->exactly(2))->method('has')->willReturnMap([
+        $parameterBag = $this->createMock(ParameterBagInterface::class);
+        $parameterBag->expects($this->exactly(2))->method('has')->willReturnMap([
             ['foo', true],
             ['bar', false],
         ]);
-        $containerBag->expects($this->never())->method('get');
-        $sut = new Config($containerBag);
+        $parameterBag->expects($this->never())->method('get');
+        $sut = new Config($parameterBag);
 
         $this->assertTrue($sut->has('foo'));
         $this->assertFalse($sut->has('bar'));
@@ -49,9 +49,9 @@ class ConfigTest extends TestCase
      */
     public function get(): void
     {
-        $containerBag = $this->createMock(ContainerBag::class);
-        $containerBag->expects($this->once())->method('get')->with('foo')->willReturn('bar');
-        $sut = new Config($containerBag);
+        $parameterBag = $this->createMock(ParameterBagInterface::class);
+        $parameterBag->expects($this->once())->method('get')->with('foo')->willReturn('bar');
+        $sut = new Config($parameterBag);
 
         $actual = $sut->get('foo');
 
@@ -63,9 +63,9 @@ class ConfigTest extends TestCase
      */
     public function access_parameters_by_period_separator(): void
     {
-        $containerBag = $this->createMock(ContainerBag::class);
-        $containerBag->expects($this->once())->method('get')->with('foo')->willReturn(['bar' => 'baz']);
-        $sut = new Config($containerBag);
+        $parameterBag = $this->createMock(ParameterBagInterface::class);
+        $parameterBag->expects($this->once())->method('get')->with('foo')->willReturn(['bar' => 'baz']);
+        $sut = new Config($parameterBag);
 
         $actual = $sut->get('foo.bar');
 
@@ -77,7 +77,7 @@ class ConfigTest extends TestCase
      */
     public function get_returns_default_value_if_value_is_missed(): void
     {
-        /** @var ContainerBag $parameterBag */
+        /** @var ParameterBagInterface $parameterBag */
         $parameterBag = $this->container()->get('parameter_bag');
         $sut = new Config($parameterBag);
 
@@ -91,7 +91,7 @@ class ConfigTest extends TestCase
      */
     public function get_returns_default_value_if_nested_parameter_is_missed(): void
     {
-        $parameterBag = $this->createMock(ContainerBag::class);
+        $parameterBag = $this->createMock(ParameterBagInterface::class);
         $parameterBag->expects($this->once())->method('get')->with('foo')->willReturn(['bar' => 'baz']);
         $sut = new Config($parameterBag);
 


### PR DESCRIPTION
| Q             | A                                                                  |
|---------------|--------------------------------------------------------------------|
| Branch?       | 1.x <!-- see below -->                                             |
| Bug fix?      | no                                                            |
| New feature?  | yes <!-- please update /CHANGELOG.md files -->                  |
| Deprecations? | no <!-- please update UPGRADE-*.md and /CHANGELOG.md files --> |
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", -->           |
| License       | MIT                                                                |

This PR adds a config helper and removes the `getConfig()` method from the Abstract action.
This is one of the steps to fix the issue reported in #165.