### PR TITLE
[1.x] Add refresh token manager

### DIFF
--- a/config/siklid.yaml
+++ b/config/siklid.yaml
@@ -6,3 +6,8 @@ parameters:
   redis:
     host: '%env(REDIS_HOST)%'
     port: '%env(REDIS_PORT)%'
+
+  security:
+    tokens:
+      refresh_token_ttl: 2592000 # 30 days
+      access_token_ttl: 3600 # 1 hour

--- a/src/Foundation/Security/Token/RefreshTokenManager.php
+++ b/src/Foundation/Security/Token/RefreshTokenManager.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Foundation\Security\Token;
+
+use App\Foundation\Action\ConfigInterface as Config;
+use Gesdinet\JWTRefreshTokenBundle\Generator\RefreshTokenGeneratorInterface as Generator;
+use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface as RefreshToken;
+use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenManagerInterface as Manager;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class RefreshTokenManager implements RefreshTokenManagerInterface
+{
+    private Generator $generator;
+    private Manager $manager;
+    private Config $config;
+
+    public function __construct(Generator $generator, Manager $manager, Config $config)
+    {
+        $this->generator = $generator;
+        $this->manager = $manager;
+        $this->config = $config;
+    }
+
+    public function createForUser(UserInterface $user, int $ttl = 0): RefreshToken
+    {
+        $ttl = $ttl > 0 ? $ttl : (int)$this->config->get('security.tokens.refresh_token_ttl');
+        $refreshToken = $this->generator->createForUserWithTtl($user, $ttl);
+        $this->manager->save($refreshToken);
+
+        return $refreshToken;
+    }
+}

--- a/src/Foundation/Security/Token/RefreshTokenManagerInterface.php
+++ b/src/Foundation/Security/Token/RefreshTokenManagerInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Foundation\Security\Token;
+
+use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface as RefreshToken;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+interface RefreshTokenManagerInterface
+{
+    public const CONFIGURED_TTL = 0;
+
+    public function createForUser(UserInterface $user, int $ttl): RefreshToken;
+}

--- a/tests/Foundation/Security/Token/RefreshTokenManagerTest.php
+++ b/tests/Foundation/Security/Token/RefreshTokenManagerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Foundation\Security\Token;
+
+use App\Foundation\Action\ConfigInterface;
+use App\Foundation\Security\Token\RefreshTokenManager;
+use App\Foundation\Security\Token\RefreshTokenManagerInterface;
+use App\Tests\Concern\Util\WithFaker;
+use App\Tests\TestCase;
+use Gesdinet\JWTRefreshTokenBundle\Generator\RefreshTokenGeneratorInterface as GesdinetGenerator;
+use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;
+use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenManagerInterface as GesdinetManager;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class RefreshTokenManagerTest extends TestCase
+{
+    use WithFaker;
+
+    /**
+     * @test
+     */
+    public function create_for_user(): void
+    {
+        $generator = $this->createMock(GesdinetGenerator::class);
+        $manager = $this->createMock(GesdinetManager::class);
+        $config = $this->createMock(ConfigInterface::class);
+        $ttl = $this->faker->numberBetween(1, 3600);
+        $config->expects($this->once())
+            ->method('get')
+            ->with('security.tokens.refresh_token_ttl')
+            ->willReturn($ttl);
+
+        $sut = new RefreshTokenManager($generator, $manager, $config);
+        $user = $this->createMock(UserInterface::class);
+
+        $refreshToken = $this->createMock(RefreshTokenInterface::class);
+        $generator->expects($this->once())
+            ->method('createForUserWithTtl')
+            ->with($user, $ttl)
+            ->willReturn($refreshToken);
+
+        $manager->expects($this->once())->method('save')->with($refreshToken);
+
+        $actual = $sut->createForUser($user, RefreshTokenManagerInterface::CONFIGURED_TTL);
+
+        $this->assertSame($refreshToken, $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function create_for_user_uses_passed_ttl_if_gt_zero(): void
+    {
+        $generator = $this->createMock(GesdinetGenerator::class);
+        $manager = $this->createMock(GesdinetManager::class);
+        $config = $this->createMock(ConfigInterface::class);
+        $ttl = $this->faker->numberBetween(1, 3600);
+        $config->expects($this->never())->method('get');
+
+        $sut = new RefreshTokenManager($generator, $manager, $config);
+        $user = $this->createMock(UserInterface::class);
+
+        $refreshToken = $this->createMock(RefreshTokenInterface::class);
+        $generator->expects($this->once())
+            ->method('createForUserWithTtl')
+            ->with($user, $ttl)
+            ->willReturn($refreshToken);
+
+        $manager->expects($this->once())->method('save')->with($refreshToken);
+
+        $actual = $sut->createForUser($user, $ttl);
+
+        $this->assertSame($refreshToken, $actual);
+    }
+}


### PR DESCRIPTION
| Q             | A                                                                  |
|---------------|--------------------------------------------------------------------|
| Branch?       | 1.x <!-- see below -->                                             |
| Bug fix?      | no                                                             |
| New feature?  | yes <!-- please update /CHANGELOG.md files -->                  |
| Deprecations? | no <!-- please update UPGRADE-*.md and /CHANGELOG.md files --> |
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", -->           |
| License       | MIT                                                                |

This PR is one of the steps required for completing the logout PR #161. It adds a refresh token manager that creates a refresh token for a specific user. The refresh token manager will be extended to revoke the refresh token in another PR.
