### PR TITLE
[1.x] Access keys without splitting the key

### DIFF
--- a/src/Foundation/Action/Config.php
+++ b/src/Foundation/Action/Config.php
@@ -36,12 +36,14 @@ class Config implements ConfigInterface
             $default instanceof UnitEnum
         );
 
-        $keyParts = explode('.', $key);
-        try {
-            $config = $this->config->get($keyParts[0]);
-        } catch (InvalidArgumentException) {
-            return $default;
+        if (str_starts_with($key, '@')) {
+            $key = substr($key, 1);
+
+            return $this->getConfigOrDefault($key, $default);
         }
+
+        $keyParts = explode('.', $key);
+        $config = $this->getConfigOrDefault($keyParts[0], $default);
 
         for ($i = 1, $iMax = count($keyParts); $i < $iMax; ++$i) {
             if ($config instanceof UnitEnum || ! isset($config[$keyParts[$i]])) {
@@ -57,5 +59,14 @@ class Config implements ConfigInterface
     public function has(string $key): bool
     {
         return $this->config->has($key);
+    }
+
+    private function getConfigOrDefault(string $key, mixed $default = null): mixed
+    {
+        try {
+            return $this->config->get($key);
+        } catch (InvalidArgumentException) {
+            return $default;
+        }
     }
 }

--- a/tests/Foundation/Action/ConfigTest.php
+++ b/tests/Foundation/Action/ConfigTest.php
@@ -81,9 +81,8 @@ class ConfigTest extends TestCase
         $parameterBag = $this->container()->get('parameter_bag');
         $sut = new Config($parameterBag);
 
-        $actual = $sut->get('foo.bar', 'default');
-
-        $this->assertSame('default', $actual);
+        $this->assertSame('default', $sut->get('foo.bar', 'default'));
+        $this->assertSame('default', $sut->get('@foo.bar', 'default'));
     }
 
     /**
@@ -98,5 +97,19 @@ class ConfigTest extends TestCase
         $actual = $sut->get('foo.baz', 'default');
 
         $this->assertSame('default', $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function access_keys_that_have_periods_in_names(): void
+    {
+        $parameterBag = $this->createMock(ParameterBagInterface::class);
+        $parameterBag->expects($this->once())->method('get')->with('foo.bar')->willReturn('baz');
+        $sut = new Config($parameterBag);
+
+        $actual = $sut->get('@foo.bar');
+
+        $this->assertSame('baz', $actual);
     }
 }


### PR DESCRIPTION
| Q             | A                                                                  |
|---------------|--------------------------------------------------------------------|
| Branch?       | 1.x <!-- see below -->                                             |
| Bug fix?      | no                                                            |
| New feature?  | yes <!-- please update /CHANGELOG.md files -->                  |
| Deprecations? | no <!-- please update UPGRADE-*.md and /CHANGELOG.md files --> |
| Tickets       | Fix #195  <!-- prefix each issue number with "Fix #", -->           |
| License       | MIT                                                                |

This PR allows accessing the configuration parameters without splitting the configuration key:

```php
$value1 = $this->config->get('@foo.bar'); // Returns the value of `foo.bar`
$value2 = $this->config->get('foo.bar'); // returns the value of ['foo' => ['bar' => <VALUE>]]
