### PR TITLE
[1.x] Revoke tokens

### DIFF
--- a/src/Foundation/Security/Token/AccessTokenInterface.php
+++ b/src/Foundation/Security/Token/AccessTokenInterface.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace App\Foundation\Security\Token;
 
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;
+use Stringable;
 
-interface AccessTokenInterface
+interface AccessTokenInterface extends Stringable
 {
     /**
      * Returns the token string.

--- a/src/Foundation/Security/Token/RefreshTokenManager.php
+++ b/src/Foundation/Security/Token/RefreshTokenManager.php
@@ -35,6 +35,5 @@ class RefreshTokenManager implements RefreshTokenManagerInterface
     public function revoke(RefreshToken $refreshToken): void
     {
         $this->manager->delete($refreshToken);
-        $this->manager->save($refreshToken);
     }
 }

--- a/src/Foundation/Security/Token/RefreshTokenManager.php
+++ b/src/Foundation/Security/Token/RefreshTokenManager.php
@@ -31,4 +31,10 @@ class RefreshTokenManager implements RefreshTokenManagerInterface
 
         return $refreshToken;
     }
+
+    public function revoke(RefreshToken $refreshToken): void
+    {
+        $this->manager->delete($refreshToken);
+        $this->manager->save($refreshToken);
+    }
 }

--- a/src/Foundation/Security/Token/RefreshTokenManagerInterface.php
+++ b/src/Foundation/Security/Token/RefreshTokenManagerInterface.php
@@ -12,4 +12,6 @@ interface RefreshTokenManagerInterface
     public const CONFIGURED_TTL = 0;
 
     public function createForUser(UserInterface $user, int $ttl): RefreshToken;
+
+    public function revoke(RefreshToken $refreshToken): void;
 }

--- a/src/Foundation/Security/Token/TokenManager.php
+++ b/src/Foundation/Security/Token/TokenManager.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Foundation\Security\Token;
 
+use App\Foundation\Action\ConfigInterface;
+use App\Foundation\Redis\Contract\SetInterface;
 use App\Foundation\Security\Token\RefreshTokenManagerInterface as RefreshTokenManager;
 use App\Siklid\Document\AccessToken;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface as JwtManager;
@@ -16,11 +18,19 @@ class TokenManager implements TokenManagerInterface
 {
     private JwtManager $jwtManager;
     private RefreshTokenManager $refreshTokenManager;
+    private SetInterface $revokedTokens;
+    private ConfigInterface $config;
 
-    public function __construct(JwtManager $jwtManager, RefreshTokenManager $refreshTokenManager)
-    {
+    public function __construct(
+        JwtManager $jwtManager,
+        RefreshTokenManager $refreshTokenManager,
+        SetInterface $revokedTokens,
+        ConfigInterface $config
+    ) {
         $this->jwtManager = $jwtManager;
         $this->refreshTokenManager = $refreshTokenManager;
+        $this->revokedTokens = $revokedTokens;
+        $this->config = $config;
     }
 
     public function createAccessToken(UserInterface $user): AccessTokenInterface
@@ -32,5 +42,17 @@ class TokenManager implements TokenManagerInterface
         $accessToken->setRefreshToken($refreshToken);
 
         return $accessToken;
+    }
+
+    public function revokeAccessTokenForUser(AccessTokenInterface $accessToken, UserInterface $user): void
+    {
+        $key = sprintf(self::REVOKED_TOKENS_KEY_PATTERNS, $user->getUserIdentifier());
+
+        $this->revokedTokens->add($key, $accessToken->getToken());
+
+        $ttl = $this->config->get('@lexik_jwt_authentication.token_ttl');
+        assert(is_int($ttl));
+
+        $this->revokedTokens->setTtl($key, $ttl);
     }
 }

--- a/src/Foundation/Security/Token/TokenManager.php
+++ b/src/Foundation/Security/Token/TokenManager.php
@@ -8,6 +8,7 @@ use App\Foundation\Action\ConfigInterface;
 use App\Foundation\Redis\Contract\SetInterface;
 use App\Foundation\Security\Token\RefreshTokenManagerInterface as RefreshTokenManager;
 use App\Siklid\Document\AccessToken;
+use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface as JwtManager;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -61,5 +62,10 @@ class TokenManager implements TokenManagerInterface
         $key = sprintf(self::REVOKED_TOKENS_KEY_PATTERNS, $user->getUserIdentifier());
 
         return $this->revokedTokens->contains($key, $accessToken);
+    }
+
+    public function revokeRefreshToken(RefreshTokenInterface $refreshToken): void
+    {
+        $this->refreshTokenManager->revoke($refreshToken);
     }
 }

--- a/src/Foundation/Security/Token/TokenManager.php
+++ b/src/Foundation/Security/Token/TokenManager.php
@@ -47,7 +47,7 @@ class TokenManager implements TokenManagerInterface
 
     public function revokeAccessTokenForUser(string $accessToken, UserInterface $user): void
     {
-        $key = sprintf(self::REVOKED_TOKENS_KEY_PATTERNS, $user->getUserIdentifier());
+        $key = sprintf(self::REVOKED_TOKENS_KEY_PATTERN, $user->getUserIdentifier());
 
         $this->revokedTokens->add($key, $accessToken);
 
@@ -59,7 +59,7 @@ class TokenManager implements TokenManagerInterface
 
     public function isAccessTokenRevokedForUser(string $accessToken, UserInterface $user): bool
     {
-        $key = sprintf(self::REVOKED_TOKENS_KEY_PATTERNS, $user->getUserIdentifier());
+        $key = sprintf(self::REVOKED_TOKENS_KEY_PATTERN, $user->getUserIdentifier());
 
         return $this->revokedTokens->contains($key, $accessToken);
     }

--- a/src/Foundation/Security/Token/TokenManager.php
+++ b/src/Foundation/Security/Token/TokenManager.php
@@ -44,15 +44,22 @@ class TokenManager implements TokenManagerInterface
         return $accessToken;
     }
 
-    public function revokeAccessTokenForUser(AccessTokenInterface $accessToken, UserInterface $user): void
+    public function revokeAccessTokenForUser(string $accessToken, UserInterface $user): void
     {
         $key = sprintf(self::REVOKED_TOKENS_KEY_PATTERNS, $user->getUserIdentifier());
 
-        $this->revokedTokens->add($key, $accessToken->getToken());
+        $this->revokedTokens->add($key, $accessToken);
 
         $ttl = $this->config->get('@lexik_jwt_authentication.token_ttl');
         assert(is_int($ttl));
 
         $this->revokedTokens->setTtl($key, $ttl);
+    }
+
+    public function isAccessTokenRevokedForUser(string $accessToken, UserInterface $user): bool
+    {
+        $key = sprintf(self::REVOKED_TOKENS_KEY_PATTERNS, $user->getUserIdentifier());
+
+        return $this->revokedTokens->contains($key, $accessToken);
     }
 }

--- a/src/Foundation/Security/Token/TokenManager.php
+++ b/src/Foundation/Security/Token/TokenManager.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Foundation\Security\Token;
 
-use App\Foundation\Action\ConfigInterface;
-use App\Foundation\Redis\Contract\SetInterface;
+use App\Foundation\Action\ConfigInterface as Config;
+use App\Foundation\Redis\Contract\SetInterface as RevokedTokens;
 use App\Foundation\Security\Token\RefreshTokenManagerInterface as RefreshTokenManager;
 use App\Siklid\Document\AccessToken;
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;
@@ -19,14 +19,14 @@ class TokenManager implements TokenManagerInterface
 {
     private JwtManager $jwtManager;
     private RefreshTokenManager $refreshTokenManager;
-    private SetInterface $revokedTokens;
-    private ConfigInterface $config;
+    private RevokedTokens $revokedTokens;
+    private Config $config;
 
     public function __construct(
         JwtManager $jwtManager,
         RefreshTokenManager $refreshTokenManager,
-        SetInterface $revokedTokens,
-        ConfigInterface $config
+        RevokedTokens $revokedTokens,
+        Config $config
     ) {
         $this->jwtManager = $jwtManager;
         $this->refreshTokenManager = $refreshTokenManager;

--- a/src/Foundation/Security/Token/TokenManagerInterface.php
+++ b/src/Foundation/Security/Token/TokenManagerInterface.php
@@ -22,5 +22,10 @@ interface TokenManagerInterface
     /**
      * Revokes the given token for the given user.
      */
-    public function revokeAccessTokenForUser(AccessTokenInterface $accessToken, UserInterface $user): void;
+    public function revokeAccessTokenForUser(string $accessToken, UserInterface $user): void;
+
+    /**
+     * Checks if the given token is revoked for the given user.
+     */
+    public function isAccessTokenRevokedForUser(string $accessToken, UserInterface $user): bool;
 }

--- a/src/Foundation/Security/Token/TokenManagerInterface.php
+++ b/src/Foundation/Security/Token/TokenManagerInterface.php
@@ -13,7 +13,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
  */
 interface TokenManagerInterface
 {
-    public const REVOKED_TOKENS_KEY_PATTERNS = 'user:%s:revoked-tokens';
+    public const REVOKED_TOKENS_KEY_PATTERN = 'user:%s:revoked-tokens';
 
     /**
      * Creates a new token for the given user.

--- a/src/Foundation/Security/Token/TokenManagerInterface.php
+++ b/src/Foundation/Security/Token/TokenManagerInterface.php
@@ -16,10 +16,11 @@ interface TokenManagerInterface
 
     /**
      * Creates a new token for the given user.
-     *
-     * @param UserInterface $user the user to create a token for
      */
     public function createAccessToken(UserInterface $user): AccessTokenInterface;
 
+    /**
+     * Revokes the given token for the given user.
+     */
     public function revokeAccessTokenForUser(AccessTokenInterface $accessToken, UserInterface $user): void;
 }

--- a/src/Foundation/Security/Token/TokenManagerInterface.php
+++ b/src/Foundation/Security/Token/TokenManagerInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Foundation\Security\Token;
 
+use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
@@ -28,4 +29,9 @@ interface TokenManagerInterface
      * Checks if the given token is revoked for the given user.
      */
     public function isAccessTokenRevokedForUser(string $accessToken, UserInterface $user): bool;
+
+    /**
+     * Revokes refresh token.
+     */
+    public function revokeRefreshToken(RefreshTokenInterface $refreshToken): void;
 }

--- a/src/Foundation/Security/Token/TokenManagerInterface.php
+++ b/src/Foundation/Security/Token/TokenManagerInterface.php
@@ -12,10 +12,14 @@ use Symfony\Component\Security\Core\User\UserInterface;
  */
 interface TokenManagerInterface
 {
+    public const REVOKED_TOKENS_KEY_PATTERNS = 'user:%s:revoked-tokens';
+
     /**
      * Creates a new token for the given user.
      *
      * @param UserInterface $user the user to create a token for
      */
     public function createAccessToken(UserInterface $user): AccessTokenInterface;
+
+    public function revokeAccessTokenForUser(AccessTokenInterface $accessToken, UserInterface $user): void;
 }

--- a/src/Siklid/Document/AccessToken.php
+++ b/src/Siklid/Document/AccessToken.php
@@ -69,4 +69,9 @@ class AccessToken implements AccessTokenInterface
     {
         return $this->refreshToken?->getRefreshToken();
     }
+
+    public function __toString(): string
+    {
+        return $this->token;
+    }
 }

--- a/tests/Foundation/Security/Token/RefreshTokenManagerTest.php
+++ b/tests/Foundation/Security/Token/RefreshTokenManagerTest.php
@@ -74,4 +74,22 @@ class RefreshTokenManagerTest extends TestCase
 
         $this->assertSame($refreshToken, $actual);
     }
+
+    /**
+     * @test
+     */
+    public function revoke(): void
+    {
+        $generator = $this->createMock(GesdinetGenerator::class);
+        $manager = $this->createMock(GesdinetManager::class);
+        $config = $this->createMock(ConfigInterface::class);
+
+        $sut = new RefreshTokenManager($generator, $manager, $config);
+        $refreshToken = $this->createMock(RefreshTokenInterface::class);
+
+        $manager->expects($this->once())->method('delete')->with($refreshToken);
+        $manager->expects($this->once())->method('save')->with($refreshToken);
+
+        $sut->revoke($refreshToken);
+    }
 }

--- a/tests/Foundation/Security/Token/RefreshTokenManagerTest.php
+++ b/tests/Foundation/Security/Token/RefreshTokenManagerTest.php
@@ -88,7 +88,6 @@ class RefreshTokenManagerTest extends TestCase
         $refreshToken = $this->createMock(RefreshTokenInterface::class);
 
         $manager->expects($this->once())->method('delete')->with($refreshToken);
-        $manager->expects($this->once())->method('save')->with($refreshToken);
 
         $sut->revoke($refreshToken);
     }

--- a/tests/Foundation/Security/Token/TokenManagerTest.php
+++ b/tests/Foundation/Security/Token/TokenManagerTest.php
@@ -52,20 +52,20 @@ class TokenManagerTest extends TestCase
     /**
      * @test
      */
-    public function revoke(): void
+    public function revoke_access_token_for_user(): void
     {
         $container = $this->container();
         $user = new User();
         $email = $this->faker->email();
         $user->setEmail(Email::fromString($email));
         $sut = $container->get(TokenManagerInterface::class);
-        $accessToken = $sut->createAccessToken($user);
+        $accessToken = $this->faker->sha256();
 
         $sut->revokeAccessTokenForUser($accessToken, $user);
 
         $revokedTokensSet = $container->get(SetInterface::class);
         $key = sprintf(TokenManagerInterface::REVOKED_TOKENS_KEY_PATTERNS, $user->getUserIdentifier());
-        $this->assertTrue($revokedTokensSet->contains($key, $accessToken->getToken()));
+        $this->assertTrue($revokedTokensSet->contains($key, $accessToken));
         $config = $container->get(ConfigInterface::class);
         $ttl = (int)$config->get('@lexik_jwt_authentication.token_ttl');
         $this->assertTrue($revokedTokensSet->getTtl($key) <= $ttl);

--- a/tests/Foundation/Security/Token/TokenManagerTest.php
+++ b/tests/Foundation/Security/Token/TokenManagerTest.php
@@ -64,7 +64,7 @@ class TokenManagerTest extends TestCase
         $sut->revokeAccessTokenForUser($accessToken, $user);
 
         $revokedTokensSet = $container->get(SetInterface::class);
-        $key = sprintf(TokenManagerInterface::REVOKED_TOKENS_KEY_PATTERNS, $user->getUserIdentifier());
+        $key = sprintf(TokenManagerInterface::REVOKED_TOKENS_KEY_PATTERN, $user->getUserIdentifier());
         $this->assertTrue($revokedTokensSet->contains($key, $accessToken));
         $config = $container->get(ConfigInterface::class);
         $ttl = (int)$config->get('@lexik_jwt_authentication.token_ttl');


### PR DESCRIPTION
| Q             | A                                                                  |
|---------------|--------------------------------------------------------------------|
| Branch?       | 1.x <!-- see below -->                                             |
| Bug fix?      | yes/no                                                             |
| New feature?  | yes/no <!-- please update /CHANGELOG.md files -->                  |
| Deprecations? | yes/no <!-- please update UPGRADE-*.md and /CHANGELOG.md files --> |
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", -->           |
| License       | MIT                                                                |

one of the steps to fix #54 
This PR allows the token managers to revoke the access tokens and refresh tokens.

After merging this PR, the token manager will provide the following functionalities:

- Create an access token (a long with a refresh token). `createAccessToken()`
- Revoke access token. `revokeAccessTokenForUser()`
- Check if the access token is revoked. `isAccessTokenRevokedForUser()`
- Revoke a refresh token. `revokeRefreshToken()`
