### PR TITLE
[1.x]: Move box voter to the box namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "piscibus/php-hashtag": "^1.1",
     "sensio/framework-extra-bundle": "^6.2.10",
     "symfony/console": "^6.2.7",
-    "symfony/dotenv": "^6.2.5",
+    "symfony/dotenv": "^6.2.7",
     "symfony/flex": "^2.2.5",
     "symfony/form": "^6.2.5",
     "symfony/framework-bundle": "^6.2.5",

--- a/composer.lock
+++ b/composer.lock
@@ -5207,16 +5207,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v6.2.5",
+            "version": "v6.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "44b7b81749fd20c1bdf4946c041050e22bc8da27"
+                "reference": "cf8d4ca1ddc1e3cc242375deb8fc23e54f5e2a1e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/44b7b81749fd20c1bdf4946c041050e22bc8da27",
-                "reference": "44b7b81749fd20c1bdf4946c041050e22bc8da27",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/cf8d4ca1ddc1e3cc242375deb8fc23e54f5e2a1e",
+                "reference": "cf8d4ca1ddc1e3cc242375deb8fc23e54f5e2a1e",
                 "shasum": ""
             },
             "require": {
@@ -5275,7 +5275,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v6.2.5"
+                "source": "https://github.com/symfony/var-dumper/tree/v6.2.7"
             },
             "funding": [
                 {
@@ -5291,7 +5291,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-20T17:45:48+00:00"
+            "time": "2023-02-24T10:42:00+00:00"
         },
         {
             "name": "symfony/var-exporter",

--- a/composer.lock
+++ b/composer.lock
@@ -1119,29 +1119,29 @@
         },
         {
             "name": "laminas/laminas-code",
-            "version": "4.8.0",
+            "version": "4.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-code.git",
-                "reference": "dd19fe8e07cc3f374308565667eecd4958c22106"
+                "reference": "ad8b36073f9ac792716478befadca0798cc15635"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-code/zipball/dd19fe8e07cc3f374308565667eecd4958c22106",
-                "reference": "dd19fe8e07cc3f374308565667eecd4958c22106",
+                "url": "https://api.github.com/repos/laminas/laminas-code/zipball/ad8b36073f9ac792716478befadca0798cc15635",
+                "reference": "ad8b36073f9ac792716478befadca0798cc15635",
                 "shasum": ""
             },
             "require": {
                 "php": "~8.1.0 || ~8.2.0"
             },
             "require-dev": {
-                "doctrine/annotations": "^1.13.3",
+                "doctrine/annotations": "^2.0.0",
                 "ext-phar": "*",
                 "laminas/laminas-coding-standard": "^2.3.0",
                 "laminas/laminas-stdlib": "^3.6.1",
-                "phpunit/phpunit": "^9.5.26",
-                "psalm/plugin-phpunit": "^0.18.0",
-                "vimeo/psalm": "^5.1.0"
+                "phpunit/phpunit": "^10.0.9",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "vimeo/psalm": "^5.7.1"
             },
             "suggest": {
                 "doctrine/annotations": "Doctrine\\Common\\Annotations >=1.0 for annotation features",
@@ -1178,7 +1178,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-12-08T02:08:23+00:00"
+            "time": "2023-03-08T11:55:01+00:00"
         },
         {
             "name": "lcobucci/clock",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b99fe15a016434b181dcb21fe5e32381",
+    "content-hash": "d4101bcf6fce26040f72e52d710140a3",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -2583,16 +2583,16 @@
         },
         {
             "name": "symfony/dotenv",
-            "version": "v6.2.5",
+            "version": "v6.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dotenv.git",
-                "reference": "1a24cb3ab1dbb8834a75c9d46e427e84baae29bc"
+                "reference": "f2b09b7ee21458779df000bd24020b6e9955b393"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dotenv/zipball/1a24cb3ab1dbb8834a75c9d46e427e84baae29bc",
-                "reference": "1a24cb3ab1dbb8834a75c9d46e427e84baae29bc",
+                "url": "https://api.github.com/repos/symfony/dotenv/zipball/f2b09b7ee21458779df000bd24020b6e9955b393",
+                "reference": "f2b09b7ee21458779df000bd24020b6e9955b393",
                 "shasum": ""
             },
             "require": {
@@ -2637,7 +2637,7 @@
                 "environment"
             ],
             "support": {
-                "source": "https://github.com/symfony/dotenv/tree/v6.2.5"
+                "source": "https://github.com/symfony/dotenv/tree/v6.2.7"
             },
             "funding": [
                 {
@@ -2653,7 +2653,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:38:09+00:00"
+            "time": "2023-02-14T08:44:56+00:00"
         },
         {
             "name": "symfony/error-handler",

--- a/src/Foundation/Security/Authentication/AccessTokenInterface.php
+++ b/src/Foundation/Security/Authentication/AccessTokenInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Foundation\Security\Token;
+namespace App\Foundation\Security\Authentication;
 
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;
 use Stringable;

--- a/src/Foundation/Security/Authentication/HasAccessToken.php
+++ b/src/Foundation/Security/Authentication/HasAccessToken.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Foundation\Security\Token;
+namespace App\Foundation\Security\Authentication;
 
 interface HasAccessToken
 {

--- a/src/Foundation/Security/Authentication/RefreshTokenManager.php
+++ b/src/Foundation/Security/Authentication/RefreshTokenManager.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Foundation\Security\Token;
+namespace App\Foundation\Security\Authentication;
 
 use App\Foundation\Action\ConfigInterface as Config;
 use Gesdinet\JWTRefreshTokenBundle\Generator\RefreshTokenGeneratorInterface as Generator;

--- a/src/Foundation/Security/Authentication/RefreshTokenManagerInterface.php
+++ b/src/Foundation/Security/Authentication/RefreshTokenManagerInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Foundation\Security\Token;
+namespace App\Foundation\Security\Authentication;
 
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface as RefreshToken;
 use Symfony\Component\Security\Core\User\UserInterface;

--- a/src/Foundation/Security/Authentication/TokenManager.php
+++ b/src/Foundation/Security/Authentication/TokenManager.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace App\Foundation\Security\Token;
+namespace App\Foundation\Security\Authentication;
 
 use App\Foundation\Action\ConfigInterface as Config;
 use App\Foundation\Redis\Contract\SetInterface as RevokedTokens;
-use App\Foundation\Security\Token\RefreshTokenManagerInterface as RefreshTokenManager;
+use App\Foundation\Security\Authentication\RefreshTokenManagerInterface as RefreshTokenManager;
 use App\Siklid\Document\AccessToken;
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface as JwtManager;

--- a/src/Foundation/Security/Authentication/TokenManagerInterface.php
+++ b/src/Foundation/Security/Authentication/TokenManagerInterface.php
@@ -8,7 +8,7 @@ use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
- * Token manager interface.
+ * Authentication manager interface.
  * All access token managers must implement this interface.
  */
 interface TokenManagerInterface

--- a/src/Foundation/Security/Authentication/TokenManagerInterface.php
+++ b/src/Foundation/Security/Authentication/TokenManagerInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Foundation\Security\Token;
+namespace App\Foundation\Security\Authentication;
 
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;
 use Symfony\Component\Security\Core\User\UserInterface;

--- a/src/Foundation/Security/Authentication/TokenManagerInterface.php
+++ b/src/Foundation/Security/Authentication/TokenManagerInterface.php
@@ -8,7 +8,7 @@ use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
- * Authentication manager interface.
+ * Token manager interface.
  * All access token managers must implement this interface.
  */
 interface TokenManagerInterface

--- a/src/Foundation/Security/Authentication/TokenSubscriber.php
+++ b/src/Foundation/Security/Authentication/TokenSubscriber.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace App\Foundation\Security\Token;
+namespace App\Foundation\Security\Authentication;
 
-use App\Foundation\Security\Token\TokenManagerInterface as Manager;
+use App\Foundation\Security\Authentication\TokenManagerInterface as Manager;
 use Lexik\Bundle\JWTAuthenticationBundle\Exception\ExpiredTokenException;
 use Lexik\Bundle\JWTAuthenticationBundle\Security\Authenticator\Token\JWTPostAuthenticationToken;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;

--- a/src/Foundation/Security/Authorization/AccessDeniedException.php
+++ b/src/Foundation/Security/Authorization/AccessDeniedException.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Foundation\Security\Authorization;
+
+use App\Foundation\Exception\RenderableInterface;
+use App\Foundation\Exception\SiklidException;
+use LogicException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+final class AccessDeniedException extends SiklidException implements RenderableInterface
+{
+    /**
+     * @var string[] The attributes that were denied access to
+     */
+    private array $attributes = [];
+
+    /**
+     * @var AuthorizableInterface|null The subject that was denied access to
+     *                                 On runtime, it should be set to a non-null value. This is just to make it the same as Symfony's AccessDeniedException
+     */
+    private AuthorizableInterface|null $subject = null;
+
+    public function __construct(string $message = 'Access Denied.', Throwable $previous = null)
+    {
+        parent::__construct($message, Response::HTTP_FORBIDDEN, $previous);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAttributes(): array
+    {
+        return $this->attributes;
+    }
+
+    /**
+     * @param string[]|string $attributes
+     */
+    public function setAttributes(array|string $attributes): void
+    {
+        $this->attributes = (array)$attributes;
+    }
+
+    public function getSubject(): AuthorizableInterface
+    {
+        $subject = $this->subject;
+        assert(! is_null($subject), new LogicException('Subject is not set'));
+
+        return $subject;
+    }
+
+    public function setSubject(AuthorizableInterface $subject): void
+    {
+        $this->subject = $subject;
+    }
+
+    public function render(): Response
+    {
+        $responseBody = [
+            'message' => $this->getMessage(),
+            'errors' => [],
+        ];
+
+        $subject = $this->getSubject();
+        $attributes = $this->getAttributes();
+
+        foreach ($attributes as $attribute) {
+            $resourceName = $subject->getHumanReadableName();
+            $responseBody['errors'][$subject->getKeyName()][] = ucfirst(strtolower("You are not allowed to $attribute this $resourceName."));
+        }
+
+        return new JsonResponse($responseBody, Response::HTTP_FORBIDDEN);
+    }
+}

--- a/src/Foundation/Security/Authorization/AuthorizableInterface.php
+++ b/src/Foundation/Security/Authorization/AuthorizableInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Foundation\Security\Authorization;
+
+interface AuthorizableInterface
+{
+    /**
+     * Returns the human-readable name of the subject.
+     */
+    public function getHumanReadableName(): string;
+
+    /**
+     * Returns a key that could be used as an array key.
+     */
+    public function getKeyName(): string;
+}

--- a/src/Foundation/Security/Authorization/AuthorizationChecker.php
+++ b/src/Foundation/Security/Authorization/AuthorizationChecker.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Foundation\Security\Authorization;
+
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface as SymfonyAuthChecker;
+
+class AuthorizationChecker implements AuthorizationCheckerInterface
+{
+    private SymfonyAuthChecker $checker;
+
+    public function __construct(SymfonyAuthChecker $checker)
+    {
+        $this->checker = $checker;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isGranted(array|string $attribute, ?AuthorizableInterface $subject = null): bool
+    {
+        return $this->checker->isGranted($attribute, $subject);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function denyAccessUnlessGranted(array|string $attribute, AuthorizableInterface $subject): void
+    {
+        if (! $this->isGranted($attribute, $subject)) {
+            $exception = new AccessDeniedException();
+            $exception->setAttributes($attribute);
+            $exception->setSubject($subject);
+            throw $exception;
+        }
+    }
+}

--- a/src/Foundation/Security/Authorization/AuthorizationCheckerInterface.php
+++ b/src/Foundation/Security/Authorization/AuthorizationCheckerInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Foundation\Security\Authorization;
+
+/**
+ * All authorization checks should be done through this interface.
+ */
+interface AuthorizationCheckerInterface
+{
+    /**
+     * Checks if the attribute is granted against the current authentication token and optionally supplied subject.
+     *
+     * @param string[]|string       $attribute A single or an array of attributes to vote on
+     * @param AuthorizableInterface $subject   the subject to secure, The object the user wants to access
+     */
+    public function isGranted(array|string $attribute, AuthorizableInterface $subject): bool;
+
+    /**
+     * Throws an exception if the attribute is not granted against the current authentication token and optionally supplied subject.
+     *
+     * @param string[]|string       $attribute A single or an array of attributes to vote on
+     * @param AuthorizableInterface $subject   the subject to secure, The object the user wants to access
+     *
+     * @throws AccessDeniedException if access is not granted
+     */
+    public function denyAccessUnlessGranted(array|string $attribute, AuthorizableInterface $subject): void;
+}

--- a/src/Siklid/Application/Auth/LoginSuccessHandler.php
+++ b/src/Siklid/Application/Auth/LoginSuccessHandler.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Siklid\Application\Auth;
 
 use App\Foundation\Http\ApiController;
-use App\Foundation\Security\Token\TokenManagerInterface;
+use App\Foundation\Security\Authentication\TokenManagerInterface;
 use App\Siklid\Document\User;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;

--- a/src/Siklid/Application/Auth/Logout.php
+++ b/src/Siklid/Application/Auth/Logout.php
@@ -6,7 +6,7 @@ namespace App\Siklid\Application\Auth;
 
 use App\Foundation\Action\AbstractAction;
 use App\Foundation\Exception\LogicException;
-use App\Foundation\Security\Token\TokenManagerInterface as TokenManager;
+use App\Foundation\Security\Authentication\TokenManagerInterface as TokenManager;
 use App\Siklid\Application\Auth\Request\LogoutRequest;
 use App\Siklid\Document\RefreshToken;
 use App\Siklid\Security\UserResolverInterface as UserResolver;

--- a/src/Siklid/Application/Auth/RegisterByEmail.php
+++ b/src/Siklid/Application/Auth/RegisterByEmail.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Siklid\Application\Auth;
 
 use App\Foundation\Action\AbstractAction;
-use App\Foundation\Security\Token\TokenManagerInterface;
+use App\Foundation\Security\Authentication\TokenManagerInterface;
 use App\Siklid\Application\Auth\Request\RegisterRequest;
 use App\Siklid\Document\User;
 use Doctrine\ODM\MongoDB\DocumentManager;

--- a/src/Siklid/Application/Box/BoxVoter.php
+++ b/src/Siklid/Application/Box/BoxVoter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Siklid\Security\Voter;
+namespace App\Siklid\Application\Box;
 
 use App\Foundation\Exception\LogicException;
 use App\Siklid\Application\Contract\Entity\BoxInterface;

--- a/src/Siklid/Document/AccessToken.php
+++ b/src/Siklid/Document/AccessToken.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Siklid\Document;
 
-use App\Foundation\Security\Token\AccessTokenInterface;
+use App\Foundation\Security\Authentication\AccessTokenInterface;
 use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenInterface;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Serializer\Annotation\SerializedName;

--- a/src/Siklid/Document/User.php
+++ b/src/Siklid/Document/User.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Siklid\Document;
 
-use App\Foundation\Security\Token\AccessTokenInterface;
-use App\Foundation\Security\Token\HasAccessToken;
+use App\Foundation\Security\Authentication\AccessTokenInterface;
+use App\Foundation\Security\Authentication\HasAccessToken;
 use App\Foundation\Validation\Constraint as AppAssert;
 use App\Foundation\ValueObject\Email;
 use App\Foundation\ValueObject\Username;

--- a/tests/Feature/Auth/LogoutTest.php
+++ b/tests/Feature/Auth/LogoutTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Feature\Auth;
 
-use App\Foundation\Security\Token\TokenManagerInterface;
+use App\Foundation\Security\Authentication\TokenManagerInterface;
 use App\Tests\Concern\Factory\UserFactoryTrait;
 use App\Tests\Concern\Util\WithJson;
 use App\Tests\Concern\WebTestCaseTrait;

--- a/tests/Foundation/Security/Authentication/RefreshTokenManagerTest.php
+++ b/tests/Foundation/Security/Authentication/RefreshTokenManagerTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Foundation\Security\Token;
+namespace App\Tests\Foundation\Security\Authentication;
 
 use App\Foundation\Action\ConfigInterface;
-use App\Foundation\Security\Token\RefreshTokenManager;
-use App\Foundation\Security\Token\RefreshTokenManagerInterface;
+use App\Foundation\Security\Authentication\RefreshTokenManager;
+use App\Foundation\Security\Authentication\RefreshTokenManagerInterface;
 use App\Tests\Concern\Util\WithFaker;
 use App\Tests\TestCase;
 use Gesdinet\JWTRefreshTokenBundle\Generator\RefreshTokenGeneratorInterface as GesdinetGenerator;

--- a/tests/Foundation/Security/Authentication/TokenManagerTest.php
+++ b/tests/Foundation/Security/Authentication/TokenManagerTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Foundation\Security\Token;
+namespace App\Tests\Foundation\Security\Authentication;
 
 use App\Foundation\Action\ConfigInterface;
 use App\Foundation\Redis\Contract\SetInterface;
-use App\Foundation\Security\Token\TokenManagerInterface;
+use App\Foundation\Security\Authentication\TokenManagerInterface;
 use App\Foundation\ValueObject\Email;
 use App\Siklid\Document\RefreshToken;
 use App\Siklid\Document\User;

--- a/tests/Foundation/Security/Authentication/TokenSubscriberTest.php
+++ b/tests/Foundation/Security/Authentication/TokenSubscriberTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Foundation\Security\Token;
+namespace App\Tests\Foundation\Security\Authentication;
 
-use App\Foundation\Security\Token\TokenManagerInterface;
-use App\Foundation\Security\Token\TokenSubscriber;
+use App\Foundation\Security\Authentication\TokenManagerInterface;
+use App\Foundation\Security\Authentication\TokenSubscriber;
 use Lexik\Bundle\JWTAuthenticationBundle\Exception\ExpiredTokenException;
 use Lexik\Bundle\JWTAuthenticationBundle\Security\Authenticator\Token\JWTPostAuthenticationToken;
 use PHPUnit\Framework\TestCase;

--- a/tests/Foundation/Security/Authorization/AccessDeniedExceptionTest.php
+++ b/tests/Foundation/Security/Authorization/AccessDeniedExceptionTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Foundation\Security\Authorization;
+
+use App\Foundation\Security\Authorization\AccessDeniedException;
+use App\Foundation\Security\Authorization\AuthorizableInterface;
+use App\Tests\Concern\Util\WithJson;
+use App\Tests\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class AccessDeniedExceptionTest extends TestCase
+{
+    use WithJson;
+
+    /**
+     * @test
+     *
+     * @param string[]|string $attributes
+     * @param string[]        $expected
+     *
+     * @dataProvider provide_attributes
+     */
+    public function set_and_get_attributes(array|string $attributes, array $expected): void
+    {
+        $sut = new AccessDeniedException();
+
+        $sut->setAttributes($attributes);
+
+        $this->assertSame($expected, $sut->getAttributes());
+    }
+
+    /** @test */
+    public function set_and_get_subject(): void
+    {
+        $sut = new AccessDeniedException();
+        $subject = $this->createMock(AuthorizableInterface::class);
+
+        $sut->setSubject($subject);
+
+        $this->assertSame($subject, $sut->getSubject());
+    }
+
+    /** @test */
+    public function render(): void
+    {
+        $sut = new AccessDeniedException();
+        $subject = $this->createMock(AuthorizableInterface::class);
+        $subject->method('getKeyName')->willReturn('user');
+        $subject->method('getHumanReadableName')->willReturn('User');
+        $sut->setSubject($subject);
+        $sut->setAttributes(['view', 'edit']);
+
+        $response = $sut->render();
+
+        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertEquals([
+            'message' => 'Access Denied.',
+            'errors' => [
+                'user' => [
+                    'You are not allowed to view this user.',
+                    'You are not allowed to edit this user.',
+                ],
+            ],
+        ], $this->json->jsonToArray((string)$response->getContent()));
+    }
+
+    public function provide_attributes(): array
+    {
+        return [
+            'array' => [
+                'attributes' => ['foo', 'bar'],
+                'expected' => ['foo', 'bar'],
+            ],
+            'string' => [
+                'attributes' => 'foo',
+                'expected' => ['foo'],
+            ],
+        ];
+    }
+}

--- a/tests/Foundation/Security/Authorization/AuthorizationCheckerTest.php
+++ b/tests/Foundation/Security/Authorization/AuthorizationCheckerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Foundation\Security\Authorization;
+
+use App\Foundation\Security\Authorization\AccessDeniedException;
+use App\Foundation\Security\Authorization\AuthorizableInterface;
+use App\Foundation\Security\Authorization\AuthorizationChecker;
+use App\Tests\Concern\KernelTestCaseTrait;
+use App\Tests\Concern\Util\WithFaker;
+use App\Tests\TestCase;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+class AuthorizationCheckerTest extends TestCase
+{
+    use KernelTestCaseTrait;
+    use WithFaker;
+
+    /** @test */
+    public function is_granted(): void
+    {
+        $checker = $this->createMock(AuthorizationCheckerInterface::class);
+        $subject = $this->createMock(AuthorizableInterface::class);
+        $expected = $this->faker->randomElement([true, false]);
+        $checker->expects($this->once())->method('isGranted')->with('view', $subject)->willReturn($expected);
+        $sut = new AuthorizationChecker($checker);
+
+        $actual = $sut->isGranted('view', $subject);
+
+        $this->assertSame($expected, $actual);
+    }
+
+    /** @test */
+    public function deny_access_unless_granted_with_authorized_user(): void
+    {
+        $checker = $this->createMock(AuthorizationCheckerInterface::class);
+        $subject = $this->createMock(AuthorizableInterface::class);
+        $checker->expects($this->once())->method('isGranted')->with('view', $subject)->willReturn(true);
+        $sut = new AuthorizationChecker($checker);
+
+        $sut->denyAccessUnlessGranted('view', $subject);
+    }
+
+    /** @test */
+    public function deny_access_unless_granted_with_un_authorized_user(): void
+    {
+        $this->expectException(AccessDeniedException::class);
+        $checker = $this->createMock(AuthorizationCheckerInterface::class);
+        $subject = $this->createMock(AuthorizableInterface::class);
+        $checker->expects($this->once())->method('isGranted')->with('view', $subject)->willReturn(false);
+        $sut = new AuthorizationChecker($checker);
+
+        $sut->denyAccessUnlessGranted('view', $subject);
+    }
+
+    /** @test */
+    public function access_denied_exception_contains_subject_and_attributes(): void
+    {
+        $this->expectException(AccessDeniedException::class);
+        $this->expectExceptionMessage('Access Denied.');
+        $checker = $this->createMock(AuthorizationCheckerInterface::class);
+        $subject = $this->createMock(AuthorizableInterface::class);
+        $checker->expects($this->once())->method('isGranted')->with('view', $subject)->willReturn(false);
+        $sut = new AuthorizationChecker($checker);
+
+        try {
+            $sut->denyAccessUnlessGranted('view', $subject);
+        } catch (AccessDeniedException $exception) {
+            $this->assertSame($subject, $exception->getSubject());
+            $this->assertSame(['view'], $exception->getAttributes());
+
+            throw $exception;
+        }
+    }
+}

--- a/tests/Siklid/Application/Auth/LoginSuccessHandlerTest.php
+++ b/tests/Siklid/Application/Auth/LoginSuccessHandlerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Siklid\Application\Auth;
 
-use App\Foundation\Security\Token\TokenManagerInterface;
+use App\Foundation\Security\Authentication\TokenManagerInterface;
 use App\Foundation\ValueObject\Email;
 use App\Foundation\ValueObject\Username;
 use App\Siklid\Application\Auth\LoginSuccessHandler;

--- a/tests/Siklid/Application/Box/BoxVoterTest.php
+++ b/tests/Siklid/Application/Box/BoxVoterTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Siklid\Security\Voter;
+namespace App\Tests\Siklid\Application\Box;
 
+use App\Siklid\Application\Box\BoxVoter;
 use App\Siklid\Document\Box;
 use App\Siklid\Document\User;
-use App\Siklid\Security\Voter\BoxVoter;
 use App\Tests\TestCase;
 
 /**


### PR DESCRIPTION
| Q             | A                                                                  |
|---------------|--------------------------------------------------------------------|
| Branch?       | 1.x <!-- see below -->                                             |
| Bug fix?      | N/A                                                            |
| New feature?  | N/A <!-- please update /CHANGELOG.md files -->                  |
| Deprecations? | N/A <!-- please update UPGRADE-*.md and /CHANGELOG.md files --> |
| Tickets       | N/A <!-- prefix each issue number with "Fix #", -->           |
| License       | MIT                                                                |

This PR moves the `BoxVoter` to the `Box` Subdomain.

 **:warning: This PR depends on :warning:**
- #241 

The diff state is as below:
https://github.com/piscibus/siklid-api/compare/1.x...move-box-voter