### PR TITLE
[Foundation][Validation] maintain the validator

### DIFF
--- a/docs/technical/README.md
+++ b/docs/technical/README.md
@@ -20,7 +20,7 @@ The API is build using PHP (Symfony) and MongoDB.
     * Routing
     * Controllers
     * Request
-    * Validation
+    * [Validation](./basic-workflow/validation.md)
     * Error Handling
     * Logging
     * Response

--- a/docs/technical/basic-workflow/validation.md
+++ b/docs/technical/basic-workflow/validation.md
@@ -1,0 +1,132 @@
+# Validation
+
+Siklid uses the [Symfony validator](https://symfony.com/doc/current/components/validator.html) to validate the data and
+the object states. This is done by injecting the `\App\Foundation\Validation\ValidatorInterface` into your action class,
+and then calling the `stopUnlessValid` method.
+
+If the validation fails, an exception is thrown, and the action is not executed. Don't worry, the exception is caught
+by the framework, and the response is returned to the client.
+
+```php
+class CreateBox extends AbstractAction 
+{
+    public function __construct(ValidatorInterface $validator)
+    {
+        $this->validator = $validator;
+    }
+    
+    private function validateSomeData(array $data): void
+    {
+        $this->validator->stopUnlessValid($data, [
+            'name' => new Assert\NotBlank(),
+            'color' => new Assert\NotBlank(),
+        ]);
+    }
+    
+    private function validateSomeEntity(Box $box): void
+    {
+        $this->validator->stopUnlessValid($box);
+        // Or you can pass the validation rules as the second argument.
+        $this->validator->stopUnlessValid($box, [
+            'name' => new Assert\NotBlank(),
+            'color' => new Assert\NotBlank(),
+        ]);
+        // Or you can pass the validation groups as the third argument.
+        $this->validator->stopUnlessValid($box, [], ['create']);
+    }
+}
+```
+
+## Validation Rules
+
+All constraints are available in
+the [Symfony documentation](https://symfony.com/doc/current/reference/constraints.html). We also have a
+custom validation rules, which are listed below.
+
+- [Exists](#exists)
+- [Slug](#slug)
+
+### Exists
+
+Validates that the value exists in the database. It requires the `document` option to be set. And the `field` option
+is optional, and it defaults to `id`. In the following example, the `user` field must be an existing user in the
+database.
+
+| Option   | Description              | Default |
+|----------|--------------------------|---------|
+| document | The document class name. |         |
+| field    | The field name.          | id      |
+
+```php
+use Symfony\Component\Validator\Constraints as Assert;
+use App\Foundation\Validation\Constraint as AppAssert;
+class Box 
+{
+    // other properties are omitted for brevity.
+    
+    #[Assert\NotBlank]
+    #[AppAssert\Exists(document: User::class)]
+    private UserInterface $user;
+}
+```
+
+### Slug
+
+Validates that the value is a valid slug. No special options are required.
+
+```php
+use Symfony\Component\Validator\Constraints as Assert;
+use App\Foundation\Validation\Constraint as AppAssert;
+
+class Box 
+{
+    // other properties are omitted for brevity.
+    
+    #[Assert\NotBlank]
+    #[AppAssert\Slug]
+    private string $slug;
+}
+```
+
+### Username
+
+Validates that the value is a valid username. No special options are required.
+
+```php
+use Symfony\Component\Validator\Constraints as Assert;
+use App\Foundation\Validation\Constraint as AppAssert;
+
+class Box 
+{
+    // other properties are omitted for brevity.
+    
+    #[Assert\NotBlank]
+    #[AppAssert\Username]
+    private string $username;
+}
+```
+
+### Unique document
+
+Validates that the whole document is unique based on the given fields.
+
+```php
+use Symfony\Component\Validator\Constraints as Assert;
+use App\Foundation\Validation\Constraint as AppAssert;
+
+#[MongoDB\Document(collection: 'users')]
+#[AppAssert\UniqueDocument(fields: ['email'])]
+#[AppAssert\UniqueDocument(fields: ['username'])]
+class User
+{
+    // other properties are omitted for brevity.
+    
+    #[Assert\NotBlank]
+    #[Assert\Email]
+    private string $email;
+    
+    #[Assert\NotBlank]
+    #[AppAssert\Username]
+    private string $username;
+}
+```

--- a/docs/technical/basic-workflow/validation.md
+++ b/docs/technical/basic-workflow/validation.md
@@ -2,7 +2,7 @@
 
 Siklid uses the [Symfony validator](https://symfony.com/doc/current/components/validator.html) to validate the data and
 the object states. This is done by injecting the `\App\Foundation\Validation\ValidatorInterface` into your action class,
-and then calling the `stopUnlessValid` method.
+and then calling the `abortUnlessValid` method.
 
 If the validation fails, an exception is thrown, and the action is not executed. Don't worry, the exception is caught
 by the framework, and the response is returned to the client.
@@ -25,14 +25,14 @@ class CreateBox extends AbstractAction
     
     private function validateSomeEntity(Box $box): void
     {
-        $this->validator->stopUnlessValid($box);
+        $this->validator->abortUnlessValid($box);
         // Or you can pass the validation rules as the second argument.
-        $this->validator->stopUnlessValid($box, [
+        $this->validator->abortUnlessValid($box, [
             'name' => new Assert\NotBlank(),
             'color' => new Assert\NotBlank(),
         ]);
         // Or you can pass the validation groups as the third argument.
-        $this->validator->stopUnlessValid($box, [], ['create']);
+        $this->validator->abortUnlessValid($box, [], ['create']);
     }
 }
 ```

--- a/src/Foundation/Http/Request.php
+++ b/src/Foundation/Http/Request.php
@@ -113,7 +113,7 @@ class Request
             null,
             $this->allowExtraFields()
         );
-        $validator->validate($this->all(), $constraint);
+        $validator->stopUnlessValid($this->all(), $constraint);
     }
 
     /**

--- a/src/Foundation/Http/Request.php
+++ b/src/Foundation/Http/Request.php
@@ -113,7 +113,7 @@ class Request
             null,
             $this->allowExtraFields()
         );
-        $validator->stopUnlessValid($this->all(), $constraint);
+        $validator->abortUnlessValid($this->all(), $constraint);
     }
 
     /**

--- a/src/Foundation/Validation/Validator.php
+++ b/src/Foundation/Validation/Validator.php
@@ -9,10 +9,6 @@ use App\Foundation\Validation\ValidatorInterface as AppValidator;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\GroupSequence;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
-use Symfony\Component\Validator\Exception\NoSuchMetadataException;
-use Symfony\Component\Validator\Mapping\MetadataInterface;
-use Symfony\Component\Validator\Validator\ContextualValidatorInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
@@ -28,20 +24,6 @@ final class Validator implements AppValidator
         $this->validator = $validator;
     }
 
-    /**
-     * Validates a value against a constraint or a list of constraints.
-     *
-     * If no constraint is passed, the constraint
-     * {@link \Symfony\Component\Validator\Constraints\Valid} is assumed.
-     *
-     * @param Constraint|Constraint[]                               $constraints The constraint(s) to validate against
-     * @param string|GroupSequence|array<string|GroupSequence>|null $groups      The validation groups to validate. If
-     *                                                                           none is given, "Default" is assumed
-     *
-     * @return ConstraintViolationListInterface A list of constraint violations
-     *                                          If the list is empty, validation
-     *                                          succeeded
-     */
     public function validate(
         mixed $value,
         Constraint|array $constraints = null,
@@ -61,100 +43,5 @@ final class Validator implements AppValidator
         }
 
         return $violations;
-    }
-
-    /**
-     * Returns the metadata for the given value.
-     *
-     * @throws NoSuchMetadataException If no metadata exists for the given value
-     */
-    public function getMetadataFor(mixed $value): MetadataInterface
-    {
-        return $this->validator->getMetadataFor($value);
-    }
-
-    /**
-     * Returns whether the class is able to return metadata for the given value.
-     */
-    public function hasMetadataFor(mixed $value): bool
-    {
-        return $this->validator->hasMetadataFor($value);
-    }
-
-    /**
-     * Validates a property of an object against the constraints specified
-     * for this property.
-     *
-     * @param string                                                $propertyName The name of the validated property
-     * @param string|GroupSequence|array<string|GroupSequence>|null $groups       The validation groups to validate. If
-     *                                                                            none is given, "Default" is assumed
-     *
-     * @return ConstraintViolationListInterface A list of constraint violations
-     *                                          If the list is empty, validation
-     *                                          succeeded
-     */
-    public function validateProperty(
-        object $object,
-        string $propertyName,
-        array|GroupSequence|string $groups = null
-    ): ConstraintViolationListInterface {
-        return $this->validator->validateProperty(
-            $object,
-            $propertyName,
-            $groups
-        );
-    }
-
-    /**
-     * Validates a value against the constraints specified for an object's
-     * property.
-     *
-     * @param object|string                                         $objectOrClass The object or its class name
-     * @param string                                                $propertyName  The name of the property
-     * @param mixed                                                 $value         The value to validate against the
-     *                                                                             property's constraints
-     * @param string|GroupSequence|array<string|GroupSequence>|null $groups        The validation groups to validate.
-     *                                                                             If none is given, "Default" is
-     *                                                                             assumed
-     *
-     * @return ConstraintViolationListInterface A list of constraint violations
-     *                                          If the list is empty, validation
-     *                                          succeeded
-     */
-    public function validatePropertyValue(
-        object|string $objectOrClass,
-        string $propertyName,
-        mixed $value,
-        array|GroupSequence|string $groups = null
-    ): ConstraintViolationListInterface {
-        return $this->validator->validatePropertyValue(
-            $objectOrClass,
-            $propertyName,
-            $value,
-            $groups
-        );
-    }
-
-    /**
-     * Starts a new validation context and returns a validator for that context.
-     *
-     * The returned validator collects all violations generated within its
-     * context. You can access these violations with the
-     * {@link ContextualValidatorInterface::getViolations()} method.
-     */
-    public function startContext(): ContextualValidatorInterface
-    {
-        return $this->validator->startContext();
-    }
-
-    /**
-     * Returns a validator in the given execution context.
-     *
-     * The returned validator adds all generated violations to the given
-     * context.
-     */
-    public function inContext(ExecutionContextInterface $context): ContextualValidatorInterface
-    {
-        return $this->validator->inContext($context);
     }
 }

--- a/src/Foundation/Validation/Validator.php
+++ b/src/Foundation/Validation/Validator.php
@@ -24,7 +24,10 @@ final class Validator implements AppValidator
         $this->validator = $validator;
     }
 
-    public function validate(
+    /**
+     * {@inheritdoc}
+     */
+    public function stopUnlessValid(
         mixed $value,
         Constraint|array $constraints = null,
         string|GroupSequence|array $groups =

--- a/src/Foundation/Validation/Validator.php
+++ b/src/Foundation/Validation/Validator.php
@@ -8,7 +8,6 @@ use App\Foundation\Exception\ValidationException;
 use App\Foundation\Validation\ValidatorInterface as AppValidator;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\GroupSequence;
-use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
@@ -32,7 +31,7 @@ final class Validator implements AppValidator
         Constraint|array $constraints = null,
         string|GroupSequence|array $groups =
         null
-    ): ConstraintViolationListInterface {
+    ): void {
         $violations = $this->validator->validate(
             $value,
             $constraints,
@@ -44,7 +43,5 @@ final class Validator implements AppValidator
             $validationException->setViolationList($violations);
             throw $validationException;
         }
-
-        return $violations;
     }
 }

--- a/src/Foundation/Validation/Validator.php
+++ b/src/Foundation/Validation/Validator.php
@@ -26,7 +26,7 @@ final class Validator implements AppValidator
     /**
      * {@inheritdoc}
      */
-    public function stopUnlessValid(
+    public function abortUnlessValid(
         mixed $value,
         Constraint|array $constraints = null,
         string|GroupSequence|array $groups =

--- a/src/Foundation/Validation/ValidatorInterface.php
+++ b/src/Foundation/Validation/ValidatorInterface.php
@@ -7,7 +7,6 @@ namespace App\Foundation\Validation;
 use App\Foundation\Exception\ValidationException;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\GroupSequence;
-use Symfony\Component\Validator\ConstraintViolationListInterface;
 
 /**
  * Validates a value against a constraint or a list of constraints.
@@ -24,16 +23,11 @@ interface ValidatorInterface
      * @param string|GroupSequence|array<string|GroupSequence>|null $groups      The validation groups to validate. If
      *                                                                           none is given, "Default" is assumed
      *
-     * @return ConstraintViolationListInterface A list of constraint violations
-     *                                          If the list is empty, validation
-     *                                          succeeded
-     *
      * @throws ValidationException When validation fails
      */
     public function stopUnlessValid(
         mixed $value,
         Constraint|array $constraints = null,
-        string|GroupSequence|array $groups =
-        null
-    ): ConstraintViolationListInterface;
+        string|GroupSequence|array $groups = null
+    ): void;
 }

--- a/src/Foundation/Validation/ValidatorInterface.php
+++ b/src/Foundation/Validation/ValidatorInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Foundation\Validation;
 
+use App\Foundation\Exception\ValidationException;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\GroupSequence;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
@@ -14,7 +15,7 @@ use Symfony\Component\Validator\ConstraintViolationListInterface;
 interface ValidatorInterface
 {
     /**
-     * Validates a value against a constraint or a list of constraints.
+     * Throws a ValidationException when validation fails.
      *
      * If no constraint is passed, the constraint
      * {@link \Symfony\Component\Validator\Constraints\Valid} is assumed.
@@ -26,8 +27,10 @@ interface ValidatorInterface
      * @return ConstraintViolationListInterface A list of constraint violations
      *                                          If the list is empty, validation
      *                                          succeeded
+     *
+     * @throws ValidationException When validation fails
      */
-    public function validate(
+    public function stopUnlessValid(
         mixed $value,
         Constraint|array $constraints = null,
         string|GroupSequence|array $groups =

--- a/src/Foundation/Validation/ValidatorInterface.php
+++ b/src/Foundation/Validation/ValidatorInterface.php
@@ -25,7 +25,7 @@ interface ValidatorInterface
      *
      * @throws ValidationException When validation fails
      */
-    public function stopUnlessValid(
+    public function abortUnlessValid(
         mixed $value,
         Constraint|array $constraints = null,
         string|GroupSequence|array $groups = null

--- a/src/Siklid/Application/Box/CreateBox.php
+++ b/src/Siklid/Application/Box/CreateBox.php
@@ -39,7 +39,7 @@ final class CreateBox extends AbstractAction
         $box->setUser($this->userResolver->getUser());
         $box->setHashtags(extract_hashtags((string)$box->getDescription()));
 
-        $this->validator->stopUnlessValid($box);
+        $this->validator->abortUnlessValid($box);
 
         $this->dm->persist($box);
         $this->dm->flush();

--- a/src/Siklid/Application/Box/CreateBox.php
+++ b/src/Siklid/Application/Box/CreateBox.php
@@ -39,7 +39,7 @@ final class CreateBox extends AbstractAction
         $box->setUser($this->userResolver->getUser());
         $box->setHashtags(extract_hashtags((string)$box->getDescription()));
 
-        $this->validator->validate($box);
+        $this->validator->stopUnlessValid($box);
 
         $this->dm->persist($box);
         $this->dm->flush();

--- a/src/Siklid/Application/Flashcard/CreateFlashcard.php
+++ b/src/Siklid/Application/Flashcard/CreateFlashcard.php
@@ -39,7 +39,7 @@ class CreateFlashcard extends AbstractAction
         $flashcard->setBack($this->request->back());
         $flashcard->setBoxes($this->boxes());
 
-        $this->validator->stopUnlessValid($flashcard);
+        $this->validator->abortUnlessValid($flashcard);
 
         $this->dm->persist($flashcard);
         $this->dm->flush();

--- a/src/Siklid/Application/Flashcard/CreateFlashcard.php
+++ b/src/Siklid/Application/Flashcard/CreateFlashcard.php
@@ -39,7 +39,7 @@ class CreateFlashcard extends AbstractAction
         $flashcard->setBack($this->request->back());
         $flashcard->setBoxes($this->boxes());
 
-        $this->validator->validate($flashcard);
+        $this->validator->stopUnlessValid($flashcard);
 
         $this->dm->persist($flashcard);
         $this->dm->flush();

--- a/tests/Foundation/Http/RequestTest.php
+++ b/tests/Foundation/Http/RequestTest.php
@@ -203,7 +203,7 @@ class RequestTest extends TestCase
         $constraint = new Assert\Collection([], null, null, true);
         $validator = $this->createMock(ValidatorInterface::class);
         $validator->expects($this->once())
-            ->method('validate')
+            ->method('stopUnlessValid')
             ->with([], $constraint);
         $sut = new Sut($this->requestStack, new RequestUtil($this->json, $validator));
         $this->requestStack->push(new Request());

--- a/tests/Foundation/Http/RequestTest.php
+++ b/tests/Foundation/Http/RequestTest.php
@@ -203,7 +203,7 @@ class RequestTest extends TestCase
         $constraint = new Assert\Collection([], null, null, true);
         $validator = $this->createMock(ValidatorInterface::class);
         $validator->expects($this->once())
-            ->method('stopUnlessValid')
+            ->method('abortUnlessValid')
             ->with([], $constraint);
         $sut = new Sut($this->requestStack, new RequestUtil($this->json, $validator));
         $this->requestStack->push(new Request());

--- a/tests/Foundation/Validation/ValidatorTest.php
+++ b/tests/Foundation/Validation/ValidatorTest.php
@@ -18,25 +18,25 @@ class ValidatorTest extends TestCase
     /**
      * @test
      */
-    public function validate_with_invalid_data(): void
+    public function stop_unless_valid_with_invalid_data(): void
     {
         $this->expectException(ValidationException::class);
 
         $validator = $this->container()->get(ValidatorInterface::class);
         $sut = new Validator($validator);
 
-        $sut->validate(new Foo());
+        $sut->stopUnlessValid(new Foo());
     }
 
     /**
      * @test
      */
-    public function validate_with_valid_data(): void
+    public function stop_unless_valid_with_valid_data(): void
     {
         $validator = $this->container()->get(ValidatorInterface::class);
         $sut = new Validator($validator);
 
-        $violations = $sut->validate(new Foo('foo'));
+        $violations = $sut->stopUnlessValid(new Foo('foo'));
         $this->assertCount(0, $violations);
     }
 }

--- a/tests/Foundation/Validation/ValidatorTest.php
+++ b/tests/Foundation/Validation/ValidatorTest.php
@@ -6,14 +6,25 @@ namespace App\Tests\Foundation\Validation;
 
 use App\Foundation\Exception\ValidationException;
 use App\Foundation\Validation\Validator;
+use App\Foundation\Validation\ValidatorInterface;
 use App\Tests\Concern\KernelTestCaseTrait;
 use App\Tests\TestCase;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface as SymfonyValidator;
 
 class ValidatorTest extends TestCase
 {
     use KernelTestCaseTrait;
+
+    private ValidatorInterface $sut;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $validator = $this->container()->get(SymfonyValidator::class);
+        $this->sut = new Validator($validator);
+    }
 
     /**
      * @test
@@ -22,10 +33,7 @@ class ValidatorTest extends TestCase
     {
         $this->expectException(ValidationException::class);
 
-        $validator = $this->container()->get(ValidatorInterface::class);
-        $sut = new Validator($validator);
-
-        $sut->stopUnlessValid(new Foo());
+        $this->sut->stopUnlessValid(new Foo());
     }
 
     /**
@@ -33,11 +41,9 @@ class ValidatorTest extends TestCase
      */
     public function stop_unless_valid_with_valid_data(): void
     {
-        $validator = $this->container()->get(ValidatorInterface::class);
-        $sut = new Validator($validator);
+        $this->expectNotToPerformAssertions();
 
-        $violations = $sut->stopUnlessValid(new Foo('foo'));
-        $this->assertCount(0, $violations);
+        $this->sut->stopUnlessValid(new Foo('foo'));
     }
 }
 

--- a/tests/Foundation/Validation/ValidatorTest.php
+++ b/tests/Foundation/Validation/ValidatorTest.php
@@ -33,7 +33,7 @@ class ValidatorTest extends TestCase
     {
         $this->expectException(ValidationException::class);
 
-        $this->sut->stopUnlessValid(new Foo());
+        $this->sut->abortUnlessValid(new Foo());
     }
 
     /**
@@ -43,7 +43,7 @@ class ValidatorTest extends TestCase
     {
         $this->expectNotToPerformAssertions();
 
-        $this->sut->stopUnlessValid(new Foo('foo'));
+        $this->sut->abortUnlessValid(new Foo('foo'));
     }
 }
 


### PR DESCRIPTION
| Q             | A                                                                  |
|---------------|--------------------------------------------------------------------|
| Branch?       | 1.x <!-- see below -->                                             |
| Bug fix?      | yes/no                                                             |
| New feature?  | yes/no <!-- please update /CHANGELOG.md files -->                  |
| Deprecations? | yes/no <!-- please update UPGRADE-*.md and /CHANGELOG.md files --> |
| Tickets       | Fix #270  <!-- prefix each issue number with "Fix #", -->           |
| License       | MIT                                                                |

This PR simplifies the Validator class and interface by:

1. removing all the unused methods.
2. Renames the `validate` method to `abortUnlessValid` to make it more clear what it does.

And also, it adds documentation to the validation and how to use it.